### PR TITLE
Implement pagination and rate limiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,6 @@ export const VERSION = "0.1.0";
 
 export { HetznerClient, HetznerError, RateLimitError } from "./client.ts";
 export type { HetznerClientOptions, QueryParams } from "./client.ts";
+
+export { paginate, fetchAllPages } from "./pagination.ts";
+export type { Pagination, PaginatedResponse, PaginatedData } from "./pagination.ts";

--- a/src/pagination.test.ts
+++ b/src/pagination.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { HetznerClient } from "./client.ts";
+import { paginate, type PaginatedData } from "./pagination.ts";
+
+describe("Pagination", () => {
+  const mockToken = "test-api-token";
+  let client: HetznerClient;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  beforeEach(() => {
+    client = new HetznerClient(mockToken);
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("PaginatedResponse", () => {
+    it("includes pagination metadata", () => {
+      const response: PaginatedData<{ id: number }, "servers"> = {
+        servers: [{ id: 1 }, { id: 2 }],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: 2,
+            last_page: 4,
+            total_entries: 100,
+          },
+        },
+      };
+
+      assert.strictEqual(response.meta.pagination.page, 1);
+      assert.strictEqual(response.meta.pagination.total_entries, 100);
+      assert.strictEqual(response.meta.pagination.next_page, 2);
+    });
+  });
+
+  describe("paginate", () => {
+    it("fetches all pages automatically", async () => {
+      const page1 = {
+        servers: [{ id: 1 }, { id: 2 }],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 2,
+            previous_page: null,
+            next_page: 2,
+            last_page: 2,
+            total_entries: 4,
+          },
+        },
+      };
+      const page2 = {
+        servers: [{ id: 3 }, { id: 4 }],
+        meta: {
+          pagination: {
+            page: 2,
+            per_page: 2,
+            previous_page: 1,
+            next_page: null,
+            last_page: 2,
+            total_entries: 4,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation((url: string) => {
+        if (url.includes("page=2")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(page2), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            })
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify(page1), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      });
+
+      const items: { id: number }[] = [];
+      for await (const server of paginate(client, "/servers", "servers")) {
+        items.push(server);
+      }
+
+      assert.strictEqual(items.length, 4);
+      assert.deepStrictEqual(items, [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
+    });
+
+    it("handles single page response", async () => {
+      const response = {
+        servers: [{ id: 1 }],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const items: { id: number }[] = [];
+      for await (const server of paginate(client, "/servers", "servers")) {
+        items.push(server);
+      }
+
+      assert.strictEqual(items.length, 1);
+      assert.strictEqual(fetchMock.mock.callCount(), 1);
+    });
+
+    it("passes query parameters to requests", async () => {
+      const response = {
+        servers: [{ id: 1 }],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 10,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const items: { id: number }[] = [];
+      for await (const server of paginate(client, "/servers", "servers", {
+        per_page: 10,
+        status: "running",
+      })) {
+        items.push(server);
+      }
+
+      const [url] = fetchMock.mock.calls[0]?.arguments ?? [];
+      assert.ok((url as string).includes("per_page=10"));
+      assert.ok((url as string).includes("status=running"));
+    });
+  });
+
+  describe("rate limiting with retry", () => {
+    it("retries on rate limit with exponential backoff", async () => {
+      const errorResponse = {
+        error: {
+          code: "rate_limit_exceeded",
+          message: "rate limit exceeded",
+        },
+      };
+      const successResponse = {
+        servers: [{ id: 1 }],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      let callCount = 0;
+      fetchMock.mock.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            new Response(JSON.stringify(errorResponse), {
+              status: 429,
+              headers: {
+                "Content-Type": "application/json",
+                "Retry-After": "0",
+              },
+            })
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify(successResponse), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      });
+
+      const items: { id: number }[] = [];
+      for await (const server of paginate(client, "/servers", "servers")) {
+        items.push(server);
+      }
+
+      assert.strictEqual(items.length, 1);
+      assert.strictEqual(callCount, 2);
+    });
+  });
+});

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,0 +1,74 @@
+import { HetznerClient, RateLimitError, type QueryParams } from "./client.ts";
+
+export interface Pagination {
+  page: number;
+  per_page: number;
+  previous_page: number | null;
+  next_page: number | null;
+  last_page: number;
+  total_entries: number;
+}
+
+export interface PaginatedResponse {
+  meta: {
+    pagination: Pagination;
+  };
+}
+
+export type PaginatedData<T, K extends string> = Record<K, T[]> & PaginatedResponse;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function* paginate<T>(
+  client: HetznerClient,
+  path: string,
+  key: string,
+  params: QueryParams = {}
+): AsyncGenerator<T, void, unknown> {
+  let page = 1;
+  let hasMore = true;
+  let retryCount = 0;
+  const maxRetries = 3;
+
+  while (hasMore) {
+    try {
+      const response = await client.get<PaginatedData<T, string>>(path, {
+        ...params,
+        page,
+      });
+
+      const items = response[key];
+      if (items) {
+        for (const item of items) {
+          yield item;
+        }
+      }
+
+      const pagination = response.meta.pagination;
+      hasMore = pagination.next_page !== null;
+      page = pagination.next_page ?? page + 1;
+      retryCount = 0;
+    } catch (error) {
+      if (error instanceof RateLimitError && retryCount < maxRetries) {
+        retryCount++;
+        const backoffMs = Math.max(error.retryAfter * 1000, 100 * Math.pow(2, retryCount));
+        await delay(backoffMs);
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+export async function fetchAllPages<T>(
+  client: HetznerClient,
+  path: string,
+  key: string,
+  params: QueryParams = {}
+): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of paginate<T>(client, path, key, params)) {
+    items.push(item);
+  }
+  return items;
+}


### PR DESCRIPTION
## Summary
- Add Pagination and PaginatedResponse types for API responses
- Create async generator `paginate()` for automatic pagination
- Add `fetchAllPages()` helper function
- Implement rate limit retry with exponential backoff (max 3 retries)

## Test plan
- [x] Test fetching all pages automatically
- [x] Test single page response handling
- [x] Test query parameter passthrough
- [x] Test rate limit retry with backoff

Closes #5