### PR TITLE
Add Networks resource with network management actions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,3 +86,17 @@ export type {
   VolumeUpdateParams,
   VolumeActionResponse,
 } from "./resources/volumes.ts";
+
+export { NetworksApi } from "./resources/networks.ts";
+export type {
+  Network,
+  Subnet,
+  SubnetType,
+  Route,
+  NetworksListParams,
+  NetworksListResponse,
+  NetworkCreateParams,
+  NetworkUpdateParams,
+  NetworkActionResponse,
+  SubnetParams,
+} from "./resources/networks.ts";

--- a/src/resources/networks.test.ts
+++ b/src/resources/networks.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { HetznerClient } from "../client.ts";
+import { NetworksApi, type Network } from "./networks.ts";
+import { type Action } from "./actions.ts";
+
+describe("NetworksApi", () => {
+  const mockToken = "test-api-token";
+  let client: HetznerClient;
+  let networks: NetworksApi;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  const mockAction: Action = {
+    id: 1,
+    command: "add_subnet",
+    status: "success",
+    progress: 100,
+    started: "2025-01-01T00:00:00+00:00",
+    finished: "2025-01-01T00:01:00+00:00",
+    resources: [{ id: 200, type: "network" }],
+    error: { code: "", message: "" },
+  };
+
+  const mockNetwork: Network = {
+    id: 200,
+    name: "my-network",
+    ip_range: "10.0.0.0/8",
+    subnets: [
+      {
+        type: "cloud",
+        ip_range: "10.0.1.0/24",
+        network_zone: "eu-central",
+        gateway: "10.0.0.1",
+      },
+    ],
+    routes: [
+      {
+        destination: "10.100.1.0/24",
+        gateway: "10.0.1.1",
+      },
+    ],
+    servers: [42],
+    load_balancers: [],
+    protection: { delete: false },
+    labels: { env: "test" },
+    created: "2025-01-01T00:00:00+00:00",
+    expose_routes_to_vswitch: false,
+  };
+
+  beforeEach(() => {
+    client = new HetznerClient(mockToken);
+    networks = new NetworksApi(client);
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("get", () => {
+    it("retrieves a network by id", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ network: mockNetwork }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const network = await networks.get(200);
+
+      assert.strictEqual(network.id, 200);
+      assert.strictEqual(network.name, "my-network");
+      assert.strictEqual(network.ip_range, "10.0.0.0/8");
+    });
+  });
+
+  describe("list", () => {
+    it("lists networks with pagination", async () => {
+      const response = {
+        networks: [mockNetwork],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await networks.list();
+
+      assert.strictEqual(result.networks.length, 1);
+      assert.strictEqual(result.networks[0].name, "my-network");
+    });
+  });
+
+  describe("create", () => {
+    it("creates a new network", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ network: mockNetwork }), {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await networks.create({
+        name: "my-network",
+        ip_range: "10.0.0.0/8",
+      });
+
+      assert.strictEqual(result.id, 200);
+      assert.strictEqual(result.name, "my-network");
+    });
+  });
+
+  describe("update", () => {
+    it("updates network name and labels", async () => {
+      const updatedNetwork = { ...mockNetwork, name: "new-name" };
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ network: updatedNetwork }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await networks.update(200, { name: "new-name" });
+
+      assert.strictEqual(result.name, "new-name");
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a network", async () => {
+      fetchMock.mock.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      await networks.delete(200);
+
+      assert.strictEqual(fetchMock.mock.callCount(), 1);
+    });
+  });
+
+  describe("getByName", () => {
+    it("finds network by name", async () => {
+      const response = {
+        networks: [mockNetwork],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const network = await networks.getByName("my-network");
+
+      assert.strictEqual(network?.id, 200);
+    });
+  });
+
+  describe("addSubnet", () => {
+    it("adds a subnet to the network", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ action: { ...mockAction, command: "add_subnet" } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const action = await networks.addSubnet(200, {
+        type: "cloud",
+        ip_range: "10.0.2.0/24",
+        network_zone: "eu-central",
+      });
+
+      assert.strictEqual(action.command, "add_subnet");
+    });
+  });
+
+  describe("deleteSubnet", () => {
+    it("deletes a subnet from the network", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ action: { ...mockAction, command: "delete_subnet" } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const action = await networks.deleteSubnet(200, "10.0.1.0/24");
+
+      assert.strictEqual(action.command, "delete_subnet");
+    });
+  });
+
+  describe("addRoute", () => {
+    it("adds a route to the network", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ action: { ...mockAction, command: "add_route" } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const action = await networks.addRoute(200, "10.100.2.0/24", "10.0.1.1");
+
+      assert.strictEqual(action.command, "add_route");
+    });
+  });
+
+  describe("deleteRoute", () => {
+    it("deletes a route from the network", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ action: { ...mockAction, command: "delete_route" } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const action = await networks.deleteRoute(200, "10.100.1.0/24", "10.0.1.1");
+
+      assert.strictEqual(action.command, "delete_route");
+    });
+  });
+
+  describe("changeIpRange", () => {
+    it("changes the network IP range", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ action: { ...mockAction, command: "change_ip_range" } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const action = await networks.changeIpRange(200, "10.0.0.0/16");
+
+      assert.strictEqual(action.command, "change_ip_range");
+    });
+  });
+
+  describe("changeProtection", () => {
+    it("changes network protection settings", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ action: { ...mockAction, command: "change_protection" } }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        )
+      );
+
+      const action = await networks.changeProtection(200, { delete: true });
+
+      assert.strictEqual(action.command, "change_protection");
+    });
+  });
+});

--- a/src/resources/networks.ts
+++ b/src/resources/networks.ts
@@ -1,0 +1,157 @@
+import { HetznerClient, type QueryParams } from "../client.ts";
+import { type PaginatedResponse } from "../pagination.ts";
+import { type Action } from "./actions.ts";
+
+export type SubnetType = "cloud" | "server" | "vswitch";
+
+export interface Subnet {
+  type: SubnetType;
+  ip_range: string;
+  network_zone: string;
+  gateway: string;
+  vswitch_id?: number;
+}
+
+export interface Route {
+  destination: string;
+  gateway: string;
+}
+
+export interface Network {
+  id: number;
+  name: string;
+  ip_range: string;
+  subnets: Subnet[];
+  routes: Route[];
+  servers: number[];
+  load_balancers: number[];
+  protection: { delete: boolean };
+  labels: Record<string, string>;
+  created: string;
+  expose_routes_to_vswitch: boolean;
+}
+
+export interface NetworksListParams extends QueryParams {
+  name?: string;
+  label_selector?: string;
+}
+
+export interface NetworksListResponse extends PaginatedResponse {
+  networks: Network[];
+}
+
+export interface NetworkCreateParams {
+  name: string;
+  ip_range: string;
+  subnets?: {
+    type: SubnetType;
+    ip_range?: string;
+    network_zone: string;
+    vswitch_id?: number;
+  }[];
+  routes?: Route[];
+  labels?: Record<string, string>;
+  expose_routes_to_vswitch?: boolean;
+}
+
+export interface NetworkUpdateParams {
+  name?: string;
+  labels?: Record<string, string>;
+  expose_routes_to_vswitch?: boolean;
+}
+
+export interface NetworkActionResponse {
+  action: Action;
+}
+
+export interface SubnetParams {
+  type: SubnetType;
+  ip_range?: string;
+  network_zone: string;
+  vswitch_id?: number;
+}
+
+export class NetworksApi {
+  private readonly client: HetznerClient;
+
+  constructor(client: HetznerClient) {
+    this.client = client;
+  }
+
+  async get(id: number): Promise<Network> {
+    const response = await this.client.get<{ network: Network }>(`/networks/${String(id)}`);
+    return response.network;
+  }
+
+  async list(params: NetworksListParams = {}): Promise<NetworksListResponse> {
+    return this.client.get<NetworksListResponse>("/networks", params);
+  }
+
+  async create(params: NetworkCreateParams): Promise<Network> {
+    const response = await this.client.post<{ network: Network }>("/networks", params);
+    return response.network;
+  }
+
+  async update(id: number, params: NetworkUpdateParams): Promise<Network> {
+    const response = await this.client.put<{ network: Network }>(`/networks/${String(id)}`, params);
+    return response.network;
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.client.delete(`/networks/${String(id)}`);
+  }
+
+  async getByName(name: string): Promise<Network | undefined> {
+    const response = await this.list({ name });
+    return response.networks[0];
+  }
+
+  // Network Actions
+  async addSubnet(id: number, params: SubnetParams): Promise<Action> {
+    const response = await this.client.post<NetworkActionResponse>(
+      `/networks/${String(id)}/actions/add_subnet`,
+      params
+    );
+    return response.action;
+  }
+
+  async deleteSubnet(id: number, ipRange: string): Promise<Action> {
+    const response = await this.client.post<NetworkActionResponse>(
+      `/networks/${String(id)}/actions/delete_subnet`,
+      { ip_range: ipRange }
+    );
+    return response.action;
+  }
+
+  async addRoute(id: number, destination: string, gateway: string): Promise<Action> {
+    const response = await this.client.post<NetworkActionResponse>(
+      `/networks/${String(id)}/actions/add_route`,
+      { destination, gateway }
+    );
+    return response.action;
+  }
+
+  async deleteRoute(id: number, destination: string, gateway: string): Promise<Action> {
+    const response = await this.client.post<NetworkActionResponse>(
+      `/networks/${String(id)}/actions/delete_route`,
+      { destination, gateway }
+    );
+    return response.action;
+  }
+
+  async changeIpRange(id: number, ipRange: string): Promise<Action> {
+    const response = await this.client.post<NetworkActionResponse>(
+      `/networks/${String(id)}/actions/change_ip_range`,
+      { ip_range: ipRange }
+    );
+    return response.action;
+  }
+
+  async changeProtection(id: number, protection: { delete?: boolean }): Promise<Action> {
+    const response = await this.client.post<NetworkActionResponse>(
+      `/networks/${String(id)}/actions/change_protection`,
+      protection
+    );
+    return response.action;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements NetworksApi with full CRUD operations (get, list, create, update, delete)
- Add/delete subnets with cloud, server, and vswitch types
- Add/delete routes
- Change IP range
- Change network protection settings

## Test plan

- [x] All 98 tests pass (12 new tests for networks)
- [x] Lint passes
- [x] Type checking passes
- [x] Build succeeds

Closes #17