### PR TITLE
Add Firewalls resource with firewall management actions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,3 +100,19 @@ export type {
   NetworkActionResponse,
   SubnetParams,
 } from "./resources/networks.ts";
+
+export { FirewallsApi } from "./resources/firewalls.ts";
+export type {
+  Firewall,
+  FirewallRule,
+  FirewallRuleDirection,
+  FirewallRuleProtocol,
+  FirewallResourceRef,
+  FirewallsListParams,
+  FirewallsListResponse,
+  FirewallCreateParams,
+  FirewallCreateResponse,
+  FirewallUpdateParams,
+  FirewallActionResponse,
+  FirewallActionsResponse,
+} from "./resources/firewalls.ts";

--- a/src/resources/firewalls.test.ts
+++ b/src/resources/firewalls.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { HetznerClient } from "../client.ts";
+import { FirewallsApi, type Firewall, type FirewallCreateResponse } from "./firewalls.ts";
+import { type Action } from "./actions.ts";
+
+describe("FirewallsApi", () => {
+  const mockToken = "test-api-token";
+  let client: HetznerClient;
+  let firewalls: FirewallsApi;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  const mockAction: Action = {
+    id: 1,
+    command: "set_firewall_rules",
+    status: "success",
+    progress: 100,
+    started: "2025-01-01T00:00:00+00:00",
+    finished: "2025-01-01T00:01:00+00:00",
+    resources: [{ id: 300, type: "firewall" }],
+    error: { code: "", message: "" },
+  };
+
+  const mockFirewall: Firewall = {
+    id: 300,
+    name: "my-firewall",
+    rules: [
+      {
+        direction: "in",
+        protocol: "tcp",
+        port: "80",
+        source_ips: ["0.0.0.0/0", "::/0"],
+        description: "Allow HTTP",
+      },
+      {
+        direction: "in",
+        protocol: "tcp",
+        port: "443",
+        source_ips: ["0.0.0.0/0", "::/0"],
+        description: "Allow HTTPS",
+      },
+    ],
+    applied_to: [
+      {
+        type: "server",
+        server: { id: 42 },
+      },
+    ],
+    labels: { env: "test" },
+    created: "2025-01-01T00:00:00+00:00",
+  };
+
+  beforeEach(() => {
+    client = new HetznerClient(mockToken);
+    firewalls = new FirewallsApi(client);
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("get", () => {
+    it("retrieves a firewall by id", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ firewall: mockFirewall }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const firewall = await firewalls.get(300);
+
+      assert.strictEqual(firewall.id, 300);
+      assert.strictEqual(firewall.name, "my-firewall");
+      assert.strictEqual(firewall.rules.length, 2);
+    });
+  });
+
+  describe("list", () => {
+    it("lists firewalls with pagination", async () => {
+      const response = {
+        firewalls: [mockFirewall],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await firewalls.list();
+
+      assert.strictEqual(result.firewalls.length, 1);
+      assert.strictEqual(result.firewalls[0].name, "my-firewall");
+    });
+  });
+
+  describe("create", () => {
+    it("creates a new firewall", async () => {
+      const createResponse: FirewallCreateResponse = {
+        firewall: mockFirewall,
+        actions: [mockAction],
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(createResponse), {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await firewalls.create({
+        name: "my-firewall",
+        rules: [
+          {
+            direction: "in",
+            protocol: "tcp",
+            port: "80",
+            source_ips: ["0.0.0.0/0"],
+          },
+        ],
+      });
+
+      assert.strictEqual(result.firewall.id, 300);
+      assert.strictEqual(result.firewall.name, "my-firewall");
+    });
+  });
+
+  describe("update", () => {
+    it("updates firewall name and labels", async () => {
+      const updatedFirewall = { ...mockFirewall, name: "new-name" };
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ firewall: updatedFirewall }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await firewalls.update(300, { name: "new-name" });
+
+      assert.strictEqual(result.name, "new-name");
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a firewall", async () => {
+      fetchMock.mock.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      await firewalls.delete(300);
+
+      assert.strictEqual(fetchMock.mock.callCount(), 1);
+    });
+  });
+
+  describe("getByName", () => {
+    it("finds firewall by name", async () => {
+      const response = {
+        firewalls: [mockFirewall],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const firewall = await firewalls.getByName("my-firewall");
+
+      assert.strictEqual(firewall?.id, 300);
+    });
+  });
+
+  describe("setRules", () => {
+    it("sets firewall rules", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ actions: [{ ...mockAction, command: "set_firewall_rules" }] }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        )
+      );
+
+      const actions = await firewalls.setRules(300, [
+        {
+          direction: "in",
+          protocol: "tcp",
+          port: "22",
+          source_ips: ["10.0.0.0/8"],
+        },
+      ]);
+
+      assert.strictEqual(actions.length, 1);
+      assert.strictEqual(actions[0].command, "set_firewall_rules");
+    });
+  });
+
+  describe("applyToResources", () => {
+    it("applies firewall to resources", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ actions: [{ ...mockAction, command: "apply_firewall" }] }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        )
+      );
+
+      const actions = await firewalls.applyToResources(300, [
+        { type: "server", server: { id: 42 } },
+      ]);
+
+      assert.strictEqual(actions.length, 1);
+      assert.strictEqual(actions[0].command, "apply_firewall");
+    });
+  });
+
+  describe("removeFromResources", () => {
+    it("removes firewall from resources", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ actions: [{ ...mockAction, command: "remove_firewall" }] }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        )
+      );
+
+      const actions = await firewalls.removeFromResources(300, [
+        { type: "server", server: { id: 42 } },
+      ]);
+
+      assert.strictEqual(actions.length, 1);
+      assert.strictEqual(actions[0].command, "remove_firewall");
+    });
+  });
+});

--- a/src/resources/firewalls.ts
+++ b/src/resources/firewalls.ts
@@ -1,0 +1,128 @@
+import { HetznerClient, type QueryParams } from "../client.ts";
+import { type PaginatedResponse } from "../pagination.ts";
+import { type Action } from "./actions.ts";
+
+export type FirewallRuleDirection = "in" | "out";
+export type FirewallRuleProtocol = "tcp" | "udp" | "icmp" | "esp" | "gre";
+
+export interface FirewallRule {
+  direction: FirewallRuleDirection;
+  protocol: FirewallRuleProtocol;
+  port?: string;
+  source_ips?: string[];
+  destination_ips?: string[];
+  description?: string;
+}
+
+export interface FirewallResourceRef {
+  type: "server" | "label_selector";
+  server?: { id: number };
+  label_selector?: { selector: string };
+}
+
+export interface Firewall {
+  id: number;
+  name: string;
+  rules: FirewallRule[];
+  applied_to: FirewallResourceRef[];
+  labels: Record<string, string>;
+  created: string;
+}
+
+export interface FirewallsListParams extends QueryParams {
+  name?: string;
+  label_selector?: string;
+  sort?: string;
+}
+
+export interface FirewallsListResponse extends PaginatedResponse {
+  firewalls: Firewall[];
+}
+
+export interface FirewallCreateParams {
+  name: string;
+  rules?: FirewallRule[];
+  apply_to?: FirewallResourceRef[];
+  labels?: Record<string, string>;
+}
+
+export interface FirewallCreateResponse {
+  firewall: Firewall;
+  actions?: Action[];
+}
+
+export interface FirewallUpdateParams {
+  name?: string;
+  labels?: Record<string, string>;
+}
+
+export interface FirewallActionResponse {
+  action: Action;
+}
+
+export interface FirewallActionsResponse {
+  actions: Action[];
+}
+
+export class FirewallsApi {
+  private readonly client: HetznerClient;
+
+  constructor(client: HetznerClient) {
+    this.client = client;
+  }
+
+  async get(id: number): Promise<Firewall> {
+    const response = await this.client.get<{ firewall: Firewall }>(`/firewalls/${String(id)}`);
+    return response.firewall;
+  }
+
+  async list(params: FirewallsListParams = {}): Promise<FirewallsListResponse> {
+    return this.client.get<FirewallsListResponse>("/firewalls", params);
+  }
+
+  async create(params: FirewallCreateParams): Promise<FirewallCreateResponse> {
+    return this.client.post<FirewallCreateResponse>("/firewalls", params);
+  }
+
+  async update(id: number, params: FirewallUpdateParams): Promise<Firewall> {
+    const response = await this.client.put<{ firewall: Firewall }>(
+      `/firewalls/${String(id)}`,
+      params
+    );
+    return response.firewall;
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.client.delete(`/firewalls/${String(id)}`);
+  }
+
+  async getByName(name: string): Promise<Firewall | undefined> {
+    const response = await this.list({ name });
+    return response.firewalls[0];
+  }
+
+  // Firewall Actions
+  async setRules(id: number, rules: FirewallRule[]): Promise<Action[]> {
+    const response = await this.client.post<FirewallActionsResponse>(
+      `/firewalls/${String(id)}/actions/set_rules`,
+      { rules }
+    );
+    return response.actions;
+  }
+
+  async applyToResources(id: number, resources: FirewallResourceRef[]): Promise<Action[]> {
+    const response = await this.client.post<FirewallActionsResponse>(
+      `/firewalls/${String(id)}/actions/apply_to_resources`,
+      { apply_to: resources }
+    );
+    return response.actions;
+  }
+
+  async removeFromResources(id: number, resources: FirewallResourceRef[]): Promise<Action[]> {
+    const response = await this.client.post<FirewallActionsResponse>(
+      `/firewalls/${String(id)}/actions/remove_from_resources`,
+      { remove_from: resources }
+    );
+    return response.actions;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements FirewallsApi with full CRUD operations (get, list, create, update, delete)
- Set firewall rules with direction, protocol, ports, source/destination IPs
- Apply/remove firewalls to/from servers
- Support for label selector targets

## Test plan

- [x] All 107 tests pass (9 new tests for firewalls)
- [x] Lint passes
- [x] Type checking passes
- [x] Build succeeds

Closes #19