### PR TITLE
Add Primary IPs resource with IP management actions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,3 +127,16 @@ export type {
   FloatingIPUpdateParams,
   FloatingIPActionResponse,
 } from "./resources/floating-ips.ts";
+
+export { PrimaryIPsApi } from "./resources/primary-ips.ts";
+export type {
+  PrimaryIP,
+  PrimaryIPType,
+  PrimaryIPAssigneeType,
+  PrimaryIPsListParams,
+  PrimaryIPsListResponse,
+  PrimaryIPCreateParams,
+  PrimaryIPCreateResponse,
+  PrimaryIPUpdateParams,
+  PrimaryIPActionResponse,
+} from "./resources/primary-ips.ts";

--- a/src/resources/primary-ips.test.ts
+++ b/src/resources/primary-ips.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { HetznerClient } from "../client.ts";
+import { PrimaryIPsApi, type PrimaryIP, type PrimaryIPCreateResponse } from "./primary-ips.ts";
+import { type Action } from "./actions.ts";
+
+describe("PrimaryIPsApi", () => {
+  const mockToken = "test-api-token";
+  let client: HetznerClient;
+  let primaryIPs: PrimaryIPsApi;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  const mockAction: Action = {
+    id: 1,
+    command: "assign_primary_ip",
+    status: "success",
+    progress: 100,
+    started: "2025-01-01T00:00:00+00:00",
+    finished: "2025-01-01T00:01:00+00:00",
+    resources: [{ id: 500, type: "primary_ip" }],
+    error: { code: "", message: "" },
+  };
+
+  const mockPrimaryIP: PrimaryIP = {
+    id: 500,
+    name: "my-primary-ip",
+    ip: "1.2.3.4",
+    type: "ipv4",
+    datacenter: {
+      id: 1,
+      name: "fsn1-dc14",
+      description: "Falkenstein 1 DC14",
+      location: {
+        id: 1,
+        name: "fsn1",
+        description: "Falkenstein DC Park 1",
+        country: "DE",
+        city: "Falkenstein",
+        latitude: 50.47612,
+        longitude: 12.370071,
+        network_zone: "eu-central",
+      },
+      server_types: { available: [], available_for_migration: [], supported: [] },
+    },
+    blocked: false,
+    dns_ptr: [{ ip: "1.2.3.4", dns_ptr: "server01.example.com" }],
+    assignee_id: null,
+    assignee_type: "server",
+    auto_delete: false,
+    protection: { delete: false },
+    labels: { env: "test" },
+    created: "2025-01-01T00:00:00+00:00",
+  };
+
+  beforeEach(() => {
+    client = new HetznerClient(mockToken);
+    primaryIPs = new PrimaryIPsApi(client);
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("get", () => {
+    it("retrieves a primary IP by id", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ primary_ip: mockPrimaryIP }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const primaryIP = await primaryIPs.get(500);
+
+      assert.strictEqual(primaryIP.id, 500);
+      assert.strictEqual(primaryIP.name, "my-primary-ip");
+      assert.strictEqual(primaryIP.ip, "1.2.3.4");
+    });
+  });
+
+  describe("list", () => {
+    it("lists primary IPs with pagination", async () => {
+      const response = {
+        primary_ips: [mockPrimaryIP],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await primaryIPs.list();
+
+      assert.strictEqual(result.primary_ips.length, 1);
+      assert.strictEqual(result.primary_ips[0].name, "my-primary-ip");
+    });
+  });
+
+  describe("create", () => {
+    it("creates a new primary IP", async () => {
+      const createResponse: PrimaryIPCreateResponse = {
+        primary_ip: mockPrimaryIP,
+        action: mockAction,
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(createResponse), {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await primaryIPs.create({
+        name: "my-primary-ip",
+        type: "ipv4",
+        assignee_type: "server",
+        datacenter: "fsn1-dc14",
+      });
+
+      assert.strictEqual(result.primary_ip.id, 500);
+      assert.strictEqual(result.primary_ip.type, "ipv4");
+    });
+  });
+
+  describe("update", () => {
+    it("updates primary IP name and auto_delete", async () => {
+      const updatedPrimaryIP = { ...mockPrimaryIP, name: "new-name" };
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ primary_ip: updatedPrimaryIP }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await primaryIPs.update(500, { name: "new-name" });
+
+      assert.strictEqual(result.name, "new-name");
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a primary IP", async () => {
+      fetchMock.mock.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      await primaryIPs.delete(500);
+
+      assert.strictEqual(fetchMock.mock.callCount(), 1);
+    });
+  });
+
+  describe("getByName", () => {
+    it("finds primary IP by name", async () => {
+      const response = {
+        primary_ips: [mockPrimaryIP],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const primaryIP = await primaryIPs.getByName("my-primary-ip");
+
+      assert.strictEqual(primaryIP?.id, 500);
+    });
+  });
+
+  describe("assign", () => {
+    it("assigns primary IP to server", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ action: { ...mockAction, command: "assign_primary_ip" } }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        )
+      );
+
+      const action = await primaryIPs.assign(500, 42, "server");
+
+      assert.strictEqual(action.command, "assign_primary_ip");
+    });
+  });
+
+  describe("unassign", () => {
+    it("unassigns primary IP from server", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ action: { ...mockAction, command: "unassign_primary_ip" } }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        )
+      );
+
+      const action = await primaryIPs.unassign(500);
+
+      assert.strictEqual(action.command, "unassign_primary_ip");
+    });
+  });
+
+  describe("changeDnsPtr", () => {
+    it("changes reverse DNS pointer", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ action: { ...mockAction, command: "change_dns_ptr" } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const action = await primaryIPs.changeDnsPtr(500, "1.2.3.4", "new.example.com");
+
+      assert.strictEqual(action.command, "change_dns_ptr");
+    });
+  });
+
+  describe("changeProtection", () => {
+    it("changes primary IP protection settings", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ action: { ...mockAction, command: "change_protection" } }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        )
+      );
+
+      const action = await primaryIPs.changeProtection(500, { delete: true });
+
+      assert.strictEqual(action.command, "change_protection");
+    });
+  });
+});

--- a/src/resources/primary-ips.ts
+++ b/src/resources/primary-ips.ts
@@ -1,0 +1,133 @@
+import { HetznerClient, type QueryParams } from "../client.ts";
+import { type PaginatedResponse } from "../pagination.ts";
+import { type Action } from "./actions.ts";
+import { type Datacenter } from "./datacenters.ts";
+
+export type PrimaryIPType = "ipv4" | "ipv6";
+export type PrimaryIPAssigneeType = "server";
+
+export interface PrimaryIP {
+  id: number;
+  name: string;
+  ip: string;
+  type: PrimaryIPType;
+  datacenter: Datacenter;
+  blocked: boolean;
+  dns_ptr: { ip: string; dns_ptr: string }[];
+  assignee_id: number | null;
+  assignee_type: PrimaryIPAssigneeType;
+  auto_delete: boolean;
+  protection: { delete: boolean };
+  labels: Record<string, string>;
+  created: string;
+}
+
+export interface PrimaryIPsListParams extends QueryParams {
+  name?: string;
+  label_selector?: string;
+  ip?: string;
+  sort?: string;
+}
+
+export interface PrimaryIPsListResponse extends PaginatedResponse {
+  primary_ips: PrimaryIP[];
+}
+
+export interface PrimaryIPCreateParams {
+  name: string;
+  type: PrimaryIPType;
+  assignee_type: PrimaryIPAssigneeType;
+  assignee_id?: number;
+  datacenter?: string;
+  auto_delete?: boolean;
+  labels?: Record<string, string>;
+}
+
+export interface PrimaryIPCreateResponse {
+  primary_ip: PrimaryIP;
+  action?: Action;
+}
+
+export interface PrimaryIPUpdateParams {
+  name?: string;
+  auto_delete?: boolean;
+  labels?: Record<string, string>;
+}
+
+export interface PrimaryIPActionResponse {
+  action: Action;
+}
+
+export class PrimaryIPsApi {
+  private readonly client: HetznerClient;
+
+  constructor(client: HetznerClient) {
+    this.client = client;
+  }
+
+  async get(id: number): Promise<PrimaryIP> {
+    const response = await this.client.get<{ primary_ip: PrimaryIP }>(`/primary_ips/${String(id)}`);
+    return response.primary_ip;
+  }
+
+  async list(params: PrimaryIPsListParams = {}): Promise<PrimaryIPsListResponse> {
+    return this.client.get<PrimaryIPsListResponse>("/primary_ips", params);
+  }
+
+  async create(params: PrimaryIPCreateParams): Promise<PrimaryIPCreateResponse> {
+    return this.client.post<PrimaryIPCreateResponse>("/primary_ips", params);
+  }
+
+  async update(id: number, params: PrimaryIPUpdateParams): Promise<PrimaryIP> {
+    const response = await this.client.put<{ primary_ip: PrimaryIP }>(
+      `/primary_ips/${String(id)}`,
+      params
+    );
+    return response.primary_ip;
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.client.delete(`/primary_ips/${String(id)}`);
+  }
+
+  async getByName(name: string): Promise<PrimaryIP | undefined> {
+    const response = await this.list({ name });
+    return response.primary_ips[0];
+  }
+
+  // Primary IP Actions
+  async assign(
+    id: number,
+    assigneeId: number,
+    assigneeType: PrimaryIPAssigneeType
+  ): Promise<Action> {
+    const response = await this.client.post<PrimaryIPActionResponse>(
+      `/primary_ips/${String(id)}/actions/assign`,
+      { assignee_id: assigneeId, assignee_type: assigneeType }
+    );
+    return response.action;
+  }
+
+  async unassign(id: number): Promise<Action> {
+    const response = await this.client.post<PrimaryIPActionResponse>(
+      `/primary_ips/${String(id)}/actions/unassign`
+    );
+    return response.action;
+  }
+
+  async changeDnsPtr(id: number, ip: string, dnsPtr: string | null): Promise<Action> {
+    const response = await this.client.post<PrimaryIPActionResponse>(
+      `/primary_ips/${String(id)}/actions/change_dns_ptr`,
+      { ip, dns_ptr: dnsPtr }
+    );
+    return response.action;
+  }
+
+  async changeProtection(id: number, protection: { delete?: boolean }): Promise<Action> {
+    const response = await this.client.post<PrimaryIPActionResponse>(
+      `/primary_ips/${String(id)}/actions/change_protection`,
+      protection
+    );
+    return response.action;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements PrimaryIPsApi with full CRUD operations (get, list, create, update, delete)
- Assign/unassign primary IPs to/from servers
- Change reverse DNS pointer
- Change primary IP protection settings

## Test plan

- [x] All 127 tests pass (10 new tests for primary IPs)
- [x] Lint passes
- [x] Type checking passes
- [x] Build succeeds

Closes #23