### PR TITLE
Add Load Balancer Types resource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -156,3 +156,11 @@ export type {
   CertificateUpdateParams,
   CertificateActionResponse,
 } from "./resources/certificates.ts";
+
+export { LoadBalancerTypesApi } from "./resources/load-balancer-types.ts";
+export type {
+  LoadBalancerType,
+  LoadBalancerTypePrice,
+  LoadBalancerTypesListParams,
+  LoadBalancerTypesListResponse,
+} from "./resources/load-balancer-types.ts";

--- a/src/resources/load-balancer-types.test.ts
+++ b/src/resources/load-balancer-types.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { HetznerClient } from "../client.ts";
+import { LoadBalancerTypesApi, type LoadBalancerType } from "./load-balancer-types.ts";
+
+describe("LoadBalancerTypesApi", () => {
+  const mockToken = "test-api-token";
+  let client: HetznerClient;
+  let loadBalancerTypes: LoadBalancerTypesApi;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  const mockLoadBalancerType: LoadBalancerType = {
+    id: 1,
+    name: "lb11",
+    description: "LB11",
+    max_connections: 10000,
+    max_services: 5,
+    max_targets: 25,
+    max_assigned_certificates: 10,
+    deprecated: null,
+    prices: [
+      {
+        location: "fsn1",
+        price_hourly: { net: "0.0060000000", gross: "0.0071400000" },
+        price_monthly: { net: "4.0000000000", gross: "4.7600000000" },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    client = new HetznerClient(mockToken);
+    loadBalancerTypes = new LoadBalancerTypesApi(client);
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("get", () => {
+    it("retrieves a load balancer type by id", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ load_balancer_type: mockLoadBalancerType }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const lbType = await loadBalancerTypes.get(1);
+
+      assert.strictEqual(lbType.id, 1);
+      assert.strictEqual(lbType.name, "lb11");
+      assert.strictEqual(lbType.max_connections, 10000);
+    });
+  });
+
+  describe("list", () => {
+    it("lists all load balancer types", async () => {
+      const response = {
+        load_balancer_types: [mockLoadBalancerType],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await loadBalancerTypes.list();
+
+      assert.strictEqual(result.load_balancer_types.length, 1);
+      assert.strictEqual(result.load_balancer_types[0].name, "lb11");
+    });
+  });
+
+  describe("getByName", () => {
+    it("finds load balancer type by name", async () => {
+      const response = {
+        load_balancer_types: [mockLoadBalancerType],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const lbType = await loadBalancerTypes.getByName("lb11");
+
+      assert.strictEqual(lbType?.id, 1);
+    });
+  });
+});

--- a/src/resources/load-balancer-types.ts
+++ b/src/resources/load-balancer-types.ts
@@ -1,0 +1,52 @@
+import { HetznerClient, type QueryParams } from "../client.ts";
+import { type PaginatedResponse } from "../pagination.ts";
+
+export interface LoadBalancerTypePrice {
+  location: string;
+  price_hourly: { net: string; gross: string };
+  price_monthly: { net: string; gross: string };
+}
+
+export interface LoadBalancerType {
+  id: number;
+  name: string;
+  description: string;
+  max_connections: number;
+  max_services: number;
+  max_targets: number;
+  max_assigned_certificates: number;
+  deprecated: string | null;
+  prices: LoadBalancerTypePrice[];
+}
+
+export interface LoadBalancerTypesListParams extends QueryParams {
+  name?: string;
+}
+
+export interface LoadBalancerTypesListResponse extends PaginatedResponse {
+  load_balancer_types: LoadBalancerType[];
+}
+
+export class LoadBalancerTypesApi {
+  private readonly client: HetznerClient;
+
+  constructor(client: HetznerClient) {
+    this.client = client;
+  }
+
+  async get(id: number): Promise<LoadBalancerType> {
+    const response = await this.client.get<{ load_balancer_type: LoadBalancerType }>(
+      `/load_balancer_types/${String(id)}`
+    );
+    return response.load_balancer_type;
+  }
+
+  async list(params: LoadBalancerTypesListParams = {}): Promise<LoadBalancerTypesListResponse> {
+    return this.client.get<LoadBalancerTypesListResponse>("/load_balancer_types", params);
+  }
+
+  async getByName(name: string): Promise<LoadBalancerType | undefined> {
+    const response = await this.list({ name });
+    return response.load_balancer_types[0];
+  }
+}


### PR DESCRIPTION
## Summary

- Implements LoadBalancerTypesApi with read operations (get, list)
- Get by name helper method
- Includes pricing information per location

## Test plan

- [x] All 139 tests pass (3 new tests for load balancer types)
- [x] Lint passes
- [x] Type checking passes
- [x] Build succeeds

Closes #27