### PR TITLE
Extract duplicated delay function to shared utility

### DIFF
--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,4 +1,5 @@
 import { HetznerClient, RateLimitError, type QueryParams } from "./client.ts";
+import { delay } from "./utils.ts";
 
 export interface Pagination {
   page: number;
@@ -16,8 +17,6 @@ export interface PaginatedResponse {
 }
 
 export type PaginatedData<T, K extends string> = Record<K, T[]> & PaginatedResponse;
-
-const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export async function* paginate<T>(
   client: HetznerClient,

--- a/src/resources/actions.ts
+++ b/src/resources/actions.ts
@@ -1,5 +1,6 @@
 import { HetznerClient, type QueryParams } from "../client.ts";
 import { type PaginatedResponse } from "../pagination.ts";
+import { delay } from "../utils.ts";
 
 export type ActionStatus = "running" | "success" | "error";
 
@@ -47,8 +48,6 @@ export class ActionError extends Error {
     this.action = action;
   }
 }
-
-const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export class ActionsApi {
   constructor(private readonly client: HetznerClient) {}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { delay } from "./utils.ts";
+
+describe("utils", () => {
+  describe("delay", () => {
+    it("returns a promise that resolves after the specified time", async () => {
+      const start = Date.now();
+      await delay(50);
+      const elapsed = Date.now() - start;
+
+      assert.ok(elapsed >= 45, `Expected at least 45ms, got ${String(elapsed)}ms`);
+      assert.ok(elapsed < 100, `Expected less than 100ms, got ${String(elapsed)}ms`);
+    });
+
+    it("resolves to undefined", async () => {
+      await delay(1);
+      // delay returns void/undefined - if it resolves, the test passes
+      assert.ok(true);
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Returns a promise that resolves after the specified number of milliseconds.
+ */
+export const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary
- Create `src/utils.ts` with exported `delay` function
- Update `pagination.ts` to import from utils
- Update `actions.ts` to import from utils
- Add tests for the delay utility function

This eliminates code duplication where the same `delay` function was defined in both `pagination.ts` and `actions.ts`.

## Test plan
- [x] New unit tests for `delay` function pass
- [x] All existing tests still pass
- [x] Linting passes
- [x] Type checking passes

Closes #37