### PR TITLE
Standardize constructor syntax across resource classes

### DIFF
--- a/src/resources/certificates.ts
+++ b/src/resources/certificates.ts
@@ -71,11 +71,7 @@ export interface CertificateActionResponse {
 }
 
 export class CertificatesApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<Certificate> {
     const response = await this.client.get<{ certificate: Certificate }>(

--- a/src/resources/firewalls.ts
+++ b/src/resources/firewalls.ts
@@ -65,11 +65,7 @@ export interface FirewallActionsResponse {
 }
 
 export class FirewallsApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<Firewall> {
     const response = await this.client.get<{ firewall: Firewall }>(`/firewalls/${String(id)}`);

--- a/src/resources/floating-ips.ts
+++ b/src/resources/floating-ips.ts
@@ -50,11 +50,7 @@ export interface FloatingIPActionResponse {
 }
 
 export class FloatingIPsApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<FloatingIP> {
     const response = await this.client.get<{ floating_ip: FloatingIP }>(

--- a/src/resources/load-balancer-types.ts
+++ b/src/resources/load-balancer-types.ts
@@ -28,11 +28,7 @@ export interface LoadBalancerTypesListResponse extends PaginatedResponse {
 }
 
 export class LoadBalancerTypesApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<LoadBalancerType> {
     const response = await this.client.get<{ load_balancer_type: LoadBalancerType }>(

--- a/src/resources/load-balancers.ts
+++ b/src/resources/load-balancers.ts
@@ -202,11 +202,7 @@ export interface LoadBalancerMetricsResponse {
 }
 
 export class LoadBalancersApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<LoadBalancer> {
     const response = await this.client.get<{ load_balancer: LoadBalancer }>(

--- a/src/resources/networks.ts
+++ b/src/resources/networks.ts
@@ -72,11 +72,7 @@ export interface SubnetParams {
 }
 
 export class NetworksApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<Network> {
     const response = await this.client.get<{ network: Network }>(`/networks/${String(id)}`);

--- a/src/resources/placement-groups.ts
+++ b/src/resources/placement-groups.ts
@@ -39,11 +39,7 @@ export interface PlacementGroupUpdateParams {
 }
 
 export class PlacementGroupsApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<PlacementGroup> {
     const response = await this.client.get<{ placement_group: PlacementGroup }>(

--- a/src/resources/pricing.ts
+++ b/src/resources/pricing.ts
@@ -82,11 +82,7 @@ export interface Pricing {
 }
 
 export class PricingApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(): Promise<Pricing> {
     const response = await this.client.get<{ pricing: Pricing }>("/pricing");

--- a/src/resources/primary-ips.ts
+++ b/src/resources/primary-ips.ts
@@ -59,11 +59,7 @@ export interface PrimaryIPActionResponse {
 }
 
 export class PrimaryIPsApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<PrimaryIP> {
     const response = await this.client.get<{ primary_ip: PrimaryIP }>(`/primary_ips/${String(id)}`);

--- a/src/resources/volumes.ts
+++ b/src/resources/volumes.ts
@@ -56,11 +56,7 @@ export interface VolumeActionResponse {
 }
 
 export class VolumesApi {
-  private readonly client: HetznerClient;
-
-  constructor(client: HetznerClient) {
-    this.client = client;
-  }
+  constructor(private readonly client: HetznerClient) {}
 
   async get(id: number): Promise<Volume> {
     const response = await this.client.get<{ volume: Volume }>(`/volumes/${String(id)}`);


### PR DESCRIPTION
## Summary
Convert all resource API classes to use TypeScript parameter properties (short form) for constructor parameters, ensuring consistency across the codebase.

**Before:**
```typescript
export class VolumesApi {
  private readonly client: HetznerClient;

  constructor(client: HetznerClient) {
    this.client = client;
  }
```

**After:**
```typescript
export class VolumesApi {
  constructor(private readonly client: HetznerClient) {}
```

## Updated files
- volumes.ts
- networks.ts  
- firewalls.ts
- floating-ips.ts
- primary-ips.ts
- certificates.ts
- load-balancer-types.ts
- load-balancers.ts
- placement-groups.ts
- pricing.ts

## Test plan
- [x] All existing tests still pass
- [x] Linting passes
- [x] Type checking passes

Closes #39