### PR TITLE
Add JSDoc comments to public API methods

### DIFF
--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,23 +1,56 @@
 import { HetznerClient, RateLimitError, type QueryParams } from "./client.ts";
 import { delay } from "./utils.ts";
 
+/**
+ * Pagination metadata returned by the Hetzner API.
+ */
 export interface Pagination {
+  /** Current page number */
   page: number;
+  /** Number of items per page */
   per_page: number;
+  /** Previous page number, or null if on first page */
   previous_page: number | null;
+  /** Next page number, or null if on last page */
   next_page: number | null;
+  /** Last page number */
   last_page: number;
+  /** Total number of entries across all pages */
   total_entries: number;
 }
 
+/**
+ * Base interface for paginated API responses.
+ */
 export interface PaginatedResponse {
   meta: {
     pagination: Pagination;
   };
 }
 
+/**
+ * Generic type for paginated data with a dynamic key.
+ */
 export type PaginatedData<T, K extends string> = Record<K, T[]> & PaginatedResponse;
 
+/**
+ * Async generator that iterates through all pages of a paginated API endpoint.
+ * Automatically handles pagination and rate limiting with exponential backoff.
+ *
+ * @param client - The Hetzner client instance
+ * @param path - The API endpoint path (e.g., "/servers")
+ * @param key - The key in the response containing the items array (e.g., "servers")
+ * @param params - Optional query parameters
+ * @yields Individual items from each page
+ * @throws {HetznerError} When the API returns an error after retries are exhausted
+ *
+ * @example
+ * ```typescript
+ * for await (const server of paginate(client, "/servers", "servers")) {
+ *   console.log(server.name);
+ * }
+ * ```
+ */
 export async function* paginate<T>(
   client: HetznerClient,
   path: string,
@@ -59,6 +92,22 @@ export async function* paginate<T>(
   }
 }
 
+/**
+ * Fetches all items from a paginated API endpoint and returns them as an array.
+ * This is a convenience wrapper around `paginate` for when you need all items at once.
+ *
+ * @param client - The Hetzner client instance
+ * @param path - The API endpoint path (e.g., "/servers")
+ * @param key - The key in the response containing the items array (e.g., "servers")
+ * @param params - Optional query parameters
+ * @returns Promise resolving to an array of all items
+ * @throws {HetznerError} When the API returns an error
+ *
+ * @example
+ * ```typescript
+ * const allServers = await fetchAllPages(client, "/servers", "servers");
+ * ```
+ */
 export async function fetchAllPages<T>(
   client: HetznerClient,
   path: string,

--- a/src/resources/actions.ts
+++ b/src/resources/actions.ts
@@ -2,44 +2,76 @@ import { HetznerClient, type QueryParams } from "../client.ts";
 import { type PaginatedResponse } from "../pagination.ts";
 import { delay } from "../utils.ts";
 
+/** Status of an async action */
 export type ActionStatus = "running" | "success" | "error";
 
+/** Resource affected by an action */
 export interface ActionResource {
+  /** Resource ID */
   id: number;
+  /** Resource type (e.g., "server", "volume") */
   type: string;
 }
 
+/** Error information from a failed action */
 export interface ActionErrorInfo {
+  /** Error code */
   code: string;
+  /** Human-readable error message */
   message: string;
 }
 
+/**
+ * Represents an async action in the Hetzner Cloud API.
+ * Actions are created when performing operations that take time to complete.
+ */
 export interface Action {
+  /** Unique identifier for the action */
   id: number;
+  /** Command that was executed (e.g., "create_server") */
   command: string;
+  /** Current status of the action */
   status: ActionStatus;
+  /** Progress percentage (0-100) */
   progress: number;
+  /** ISO 8601 timestamp when the action started */
   started: string;
+  /** ISO 8601 timestamp when the action finished, or null if still running */
   finished: string | null;
+  /** Resources affected by this action */
   resources: ActionResource[];
+  /** Error information if the action failed */
   error: ActionErrorInfo;
 }
 
+/** Parameters for listing actions */
 export interface ActionsListParams extends QueryParams {
+  /** Filter by action status */
   status?: ActionStatus;
+  /** Sort order (e.g., "id:asc", "started:desc") */
   sort?: string;
 }
 
+/** Response from listing actions */
 export interface ActionsListResponse extends PaginatedResponse {
   actions: Action[];
 }
 
+/**
+ * Options for polling an action until completion.
+ */
 export interface PollOptions {
+  /** Interval between status checks in milliseconds. Default: 500 */
   intervalMs?: number;
+  /** Maximum time to wait in milliseconds. Default: 300000 (5 minutes) */
   timeoutMs?: number;
 }
 
+/**
+ * Error thrown when an action fails.
+ */
 export class ActionError extends Error {
+  /** The failed action */
   readonly action: Action;
 
   constructor(action: Action, message: string) {
@@ -49,18 +81,54 @@ export class ActionError extends Error {
   }
 }
 
+/**
+ * API for tracking and managing async actions.
+ * Actions are created when performing operations like creating servers or volumes.
+ *
+ * @example
+ * ```typescript
+ * const actions = new ActionsApi(client);
+ *
+ * // Wait for an action to complete
+ * const action = await actions.poll(actionId);
+ * ```
+ */
 export class ActionsApi {
   constructor(private readonly client: HetznerClient) {}
 
+  /**
+   * Gets an action by ID.
+   * @param id - The action ID
+   * @returns The action
+   */
   async get(id: number): Promise<Action> {
     const response = await this.client.get<{ action: Action }>(`/actions/${String(id)}`);
     return response.action;
   }
 
+  /**
+   * Lists all actions with optional filtering.
+   * @param params - Optional filter and pagination parameters
+   * @returns Paginated list of actions
+   */
   async list(params: ActionsListParams = {}): Promise<ActionsListResponse> {
     return this.client.get<ActionsListResponse>("/actions", params);
   }
 
+  /**
+   * Polls an action until it completes or fails.
+   * @param id - The action ID to poll
+   * @param options - Polling options
+   * @returns The completed action
+   * @throws {ActionError} When the action fails
+   * @throws {Error} When the polling times out
+   *
+   * @example
+   * ```typescript
+   * const { action } = await servers.create({ name: "my-server", ... });
+   * await actions.poll(action.id); // Wait for server to be ready
+   * ```
+   */
   async poll(id: number, options: PollOptions = {}): Promise<Action> {
     const { intervalMs = 500, timeoutMs = 300000 } = options;
     const startTime = Date.now();


### PR DESCRIPTION
## Summary
Add comprehensive JSDoc documentation to core public APIs:

- **HetznerClient**: All methods documented with parameters, return values, and @throws
- **Error classes**: HetznerError, RateLimitError with property descriptions
- **Pagination**: Pagination interface, paginate(), fetchAllPages() with examples
- **ActionsApi**: Action interface, ActionsApi methods, ActionError, PollOptions

Documentation includes:
- Class and interface descriptions
- Method parameter descriptions
- Return value documentation
- @throws annotations for errors
- @example code snippets for common usage patterns

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] Type checking passes

Closes #41