### PR TITLE
Add unified Hetzner SDK class for easier instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,40 @@ npm install hetzner
 ## Quick Start
 
 ```typescript
-import { HetznerClient, ServersApi } from "hetzner";
+import { Hetzner } from "hetzner";
 
-const client = new HetznerClient("your-api-token");
-const servers = new ServersApi(client);
+const hetzner = new Hetzner("your-api-token");
 
 // List all servers
-const { servers: serverList } = await servers.list();
-console.log(serverList);
+const { servers } = await hetzner.servers.list();
+console.log(servers);
 
 // Get a server by name
-const server = await servers.getByName("my-server");
+const server = await hetzner.servers.getByName("my-server");
 ```
 
 ## Configuration
 
 ```typescript
-import { HetznerClient } from "hetzner";
+import { Hetzner } from "hetzner";
 
-const client = new HetznerClient("your-api-token", {
+const hetzner = new Hetzner("your-api-token", {
   baseUrl: "https://api.hetzner.cloud/v1", // optional, this is the default
 });
+
+// Access the underlying client if needed
+console.log(hetzner.client.baseUrl);
+```
+
+### Using Individual API Classes
+
+You can also use the individual API classes directly if preferred:
+
+```typescript
+import { HetznerClient, ServersApi } from "hetzner";
+
+const client = new HetznerClient("your-api-token");
+const servers = new ServersApi(client);
 ```
 
 ## Usage Examples

--- a/src/hetzner.test.ts
+++ b/src/hetzner.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { Hetzner } from "./hetzner.ts";
+import { ServersApi } from "./resources/servers.ts";
+import { VolumesApi } from "./resources/volumes.ts";
+import { NetworksApi } from "./resources/networks.ts";
+import { ActionsApi } from "./resources/actions.ts";
+import { SshKeysApi } from "./resources/ssh-keys.ts";
+import { ImagesApi } from "./resources/images.ts";
+import { LocationsApi } from "./resources/locations.ts";
+import { DatacentersApi } from "./resources/datacenters.ts";
+import { FirewallsApi } from "./resources/firewalls.ts";
+import { LoadBalancersApi } from "./resources/load-balancers.ts";
+
+describe("Hetzner", () => {
+  const mockToken = "test-api-token";
+
+  describe("constructor", () => {
+    it("creates an instance with all resource APIs", () => {
+      const hetzner = new Hetzner(mockToken);
+
+      assert.ok(hetzner.actions instanceof ActionsApi);
+      assert.ok(hetzner.servers instanceof ServersApi);
+      assert.ok(hetzner.volumes instanceof VolumesApi);
+      assert.ok(hetzner.networks instanceof NetworksApi);
+      assert.ok(hetzner.sshKeys instanceof SshKeysApi);
+      assert.ok(hetzner.images instanceof ImagesApi);
+      assert.ok(hetzner.locations instanceof LocationsApi);
+      assert.ok(hetzner.datacenters instanceof DatacentersApi);
+      assert.ok(hetzner.firewalls instanceof FirewallsApi);
+      assert.ok(hetzner.loadBalancers instanceof LoadBalancersApi);
+    });
+
+    it("accepts custom options", () => {
+      const hetzner = new Hetzner(mockToken, {
+        baseUrl: "https://custom.api.com",
+      });
+
+      assert.ok(hetzner);
+    });
+
+    it("exposes the underlying client", () => {
+      const hetzner = new Hetzner(mockToken);
+
+      assert.strictEqual(hetzner.client.baseUrl, "https://api.hetzner.cloud/v1");
+    });
+  });
+});

--- a/src/hetzner.ts
+++ b/src/hetzner.ts
@@ -1,0 +1,127 @@
+import { HetznerClient, type HetznerClientOptions } from "./client.ts";
+import { ActionsApi } from "./resources/actions.ts";
+import { CertificatesApi } from "./resources/certificates.ts";
+import { DatacentersApi } from "./resources/datacenters.ts";
+import { FirewallsApi } from "./resources/firewalls.ts";
+import { FloatingIPsApi } from "./resources/floating-ips.ts";
+import { ImagesApi } from "./resources/images.ts";
+import { IsosApi } from "./resources/isos.ts";
+import { LoadBalancerTypesApi } from "./resources/load-balancer-types.ts";
+import { LoadBalancersApi } from "./resources/load-balancers.ts";
+import { LocationsApi } from "./resources/locations.ts";
+import { NetworksApi } from "./resources/networks.ts";
+import { PlacementGroupsApi } from "./resources/placement-groups.ts";
+import { PricingApi } from "./resources/pricing.ts";
+import { PrimaryIPsApi } from "./resources/primary-ips.ts";
+import { ServerTypesApi } from "./resources/server-types.ts";
+import { ServersApi } from "./resources/servers.ts";
+import { SshKeysApi } from "./resources/ssh-keys.ts";
+import { VolumesApi } from "./resources/volumes.ts";
+
+/**
+ * Unified SDK for the Hetzner Cloud API.
+ * Provides access to all resource APIs through a single entry point.
+ *
+ * @example
+ * ```typescript
+ * const hetzner = new Hetzner("your-api-token");
+ *
+ * // Access all APIs as properties
+ * const servers = await hetzner.servers.list();
+ * const volumes = await hetzner.volumes.list();
+ *
+ * // Create a server and wait for it to be ready
+ * const { server, action } = await hetzner.servers.create({
+ *   name: "my-server",
+ *   server_type: "cx11",
+ *   image: "ubuntu-22.04",
+ * });
+ * await hetzner.actions.poll(action.id);
+ * ```
+ */
+export class Hetzner {
+  /** The underlying HTTP client */
+  readonly client: HetznerClient;
+
+  /** API for tracking async actions */
+  readonly actions: ActionsApi;
+
+  /** API for managing SSL/TLS certificates */
+  readonly certificates: CertificatesApi;
+
+  /** API for datacenter information */
+  readonly datacenters: DatacentersApi;
+
+  /** API for managing firewalls */
+  readonly firewalls: FirewallsApi;
+
+  /** API for managing floating IPs */
+  readonly floatingIPs: FloatingIPsApi;
+
+  /** API for managing images */
+  readonly images: ImagesApi;
+
+  /** API for ISO images */
+  readonly isos: IsosApi;
+
+  /** API for load balancer type information */
+  readonly loadBalancerTypes: LoadBalancerTypesApi;
+
+  /** API for managing load balancers */
+  readonly loadBalancers: LoadBalancersApi;
+
+  /** API for location information */
+  readonly locations: LocationsApi;
+
+  /** API for managing networks */
+  readonly networks: NetworksApi;
+
+  /** API for managing placement groups */
+  readonly placementGroups: PlacementGroupsApi;
+
+  /** API for pricing information */
+  readonly pricing: PricingApi;
+
+  /** API for managing primary IPs */
+  readonly primaryIPs: PrimaryIPsApi;
+
+  /** API for server type information */
+  readonly serverTypes: ServerTypesApi;
+
+  /** API for managing servers */
+  readonly servers: ServersApi;
+
+  /** API for managing SSH keys */
+  readonly sshKeys: SshKeysApi;
+
+  /** API for managing volumes */
+  readonly volumes: VolumesApi;
+
+  /**
+   * Creates a new Hetzner SDK instance.
+   * @param token - Your Hetzner Cloud API token
+   * @param options - Optional configuration options
+   */
+  constructor(token: string, options: HetznerClientOptions = {}) {
+    this.client = new HetznerClient(token, options);
+
+    this.actions = new ActionsApi(this.client);
+    this.certificates = new CertificatesApi(this.client);
+    this.datacenters = new DatacentersApi(this.client);
+    this.firewalls = new FirewallsApi(this.client);
+    this.floatingIPs = new FloatingIPsApi(this.client);
+    this.images = new ImagesApi(this.client);
+    this.isos = new IsosApi(this.client);
+    this.loadBalancerTypes = new LoadBalancerTypesApi(this.client);
+    this.loadBalancers = new LoadBalancersApi(this.client);
+    this.locations = new LocationsApi(this.client);
+    this.networks = new NetworksApi(this.client);
+    this.placementGroups = new PlacementGroupsApi(this.client);
+    this.pricing = new PricingApi(this.client);
+    this.primaryIPs = new PrimaryIPsApi(this.client);
+    this.serverTypes = new ServerTypesApi(this.client);
+    this.servers = new ServersApi(this.client);
+    this.sshKeys = new SshKeysApi(this.client);
+    this.volumes = new VolumesApi(this.client);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export const VERSION = "0.1.0";
 
+export { Hetzner } from "./hetzner.ts";
+
 export { HetznerClient, HetznerError, RateLimitError } from "./client.ts";
 export type { HetznerClientOptions, QueryParams } from "./client.ts";
 


### PR DESCRIPTION
## Summary
Add a new `Hetzner` class that provides access to all resource APIs through a single entry point.

**Before:**
```typescript
const client = new HetznerClient(token);
const servers = new ServersApi(client);
const volumes = new VolumesApi(client);
// ... must instantiate each API separately
```

**After:**
```typescript
const hetzner = new Hetzner(token);
const servers = await hetzner.servers.list();
const volumes = await hetzner.volumes.list();
// All APIs available as properties
```

## Changes
- Create `src/hetzner.ts` with `Hetzner` class
- Add tests for the new class
- Export `Hetzner` from `index.ts`
- Update README Quick Start to use new pattern
- Document individual API class usage as alternative

## Test plan
- [x] New tests for Hetzner class pass
- [x] All existing tests pass
- [x] Linting passes
- [x] Type checking passes

Closes #43