### PR TITLE
Extract calculateBackoff to utils for better testability

### DIFF
--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,5 +1,5 @@
 import { HetznerClient, RateLimitError, type QueryParams } from "./client.ts";
-import { delay } from "./utils.ts";
+import { calculateBackoff, delay } from "./utils.ts";
 
 /**
  * Pagination metadata returned by the Hetzner API.
@@ -83,8 +83,7 @@ export async function* paginate<T>(
     } catch (error) {
       if (error instanceof RateLimitError && retryCount < maxRetries) {
         retryCount++;
-        const backoffMs = Math.max(error.retryAfter * 1000, 100 * Math.pow(2, retryCount));
-        await delay(backoffMs);
+        await delay(calculateBackoff(error.retryAfter, retryCount));
         continue;
       }
       throw error;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { delay } from "./utils.ts";
+import { delay, calculateBackoff } from "./utils.ts";
 
 describe("utils", () => {
   describe("delay", () => {
@@ -17,6 +17,34 @@ describe("utils", () => {
       await delay(1);
       // delay returns void/undefined - if it resolves, the test passes
       assert.ok(true);
+    });
+  });
+
+  describe("calculateBackoff", () => {
+    it("uses retryAfter when larger than exponential backoff", () => {
+      // retryAfter = 5 seconds = 5000ms, exponential = 100 * 2^1 = 200ms
+      const result = calculateBackoff(5, 1);
+      assert.strictEqual(result, 5000);
+    });
+
+    it("uses exponential backoff when larger than retryAfter", () => {
+      // retryAfter = 0 seconds = 0ms, exponential = 100 * 2^3 = 800ms
+      const result = calculateBackoff(0, 3);
+      assert.strictEqual(result, 800);
+    });
+
+    it("calculates exponential backoff correctly", () => {
+      // retryAfter = 0, retry 1: 100 * 2^1 = 200
+      assert.strictEqual(calculateBackoff(0, 1), 200);
+      // retryAfter = 0, retry 2: 100 * 2^2 = 400
+      assert.strictEqual(calculateBackoff(0, 2), 400);
+      // retryAfter = 0, retry 3: 100 * 2^3 = 800
+      assert.strictEqual(calculateBackoff(0, 3), 800);
+    });
+
+    it("converts retryAfter seconds to milliseconds", () => {
+      const result = calculateBackoff(10, 1);
+      assert.strictEqual(result, 10000);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,14 @@
  */
 export const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Calculates backoff time for rate limit retries.
+ * Uses the larger of the Retry-After header value or an exponential backoff.
+ *
+ * @param retryAfter - The Retry-After header value in seconds
+ * @param retryCount - The current retry attempt number (1-indexed)
+ * @returns The backoff time in milliseconds
+ */
+export const calculateBackoff = (retryAfter: number, retryCount: number): number =>
+  Math.max(retryAfter * 1000, 100 * Math.pow(2, retryCount));


### PR DESCRIPTION
## Summary
Extract the backoff calculation logic from pagination.ts into a pure, testable function.

## Changes
- Add `calculateBackoff(retryAfter, retryCount)` function to utils.ts
- Add comprehensive tests for the new function
- Update pagination.ts to use the extracted function

## Benefits
- Pure function is easier to test in isolation
- Logic is reusable if needed elsewhere
- Improves code readability

## Test plan
- [x] New tests for calculateBackoff pass
- [x] All existing tests pass
- [x] Linting passes
- [x] Type checking passes

Closes #45