### PR TITLE
Add test coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc",
     "test": "node --test --experimental-transform-types --experimental-strip-types 'src/**/*.test.ts'",
+    "test:coverage": "node --test --experimental-transform-types --experimental-strip-types --experimental-test-coverage 'src/**/*.test.ts'",
     "lint": "eslint src/",
     "format": "prettier --write 'src/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts'",


### PR DESCRIPTION
## Summary
Add npm script for test coverage using Node.js built-in coverage support.

## Usage
```bash
npm run test:coverage
```

## Sample output
```
ℹ all files                |  98.46 |    97.97 |   98.49 |
```

Current coverage is ~98.5% across all files.

## Test plan
- [x] Coverage script works
- [x] All tests pass
- [x] Linting passes
- [x] Type checking passes

Closes #47