### PR TITLE
Create shared test utilities to reduce boilerplate

### DIFF
--- a/src/resources/locations.test.ts
+++ b/src/resources/locations.test.ts
@@ -1,13 +1,16 @@
-import { describe, it, beforeEach, mock } from "node:test";
+import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
-import { HetznerClient } from "../client.ts";
+import {
+  setupMockClient,
+  mockResponse,
+  mockPaginatedResponse,
+  type TestContext,
+} from "../test-utils.ts";
 import { LocationsApi, type Location } from "./locations.ts";
 
 describe("LocationsApi", () => {
-  const mockToken = "test-api-token";
-  let client: HetznerClient;
+  let ctx: TestContext;
   let locations: LocationsApi;
-  let fetchMock: ReturnType<typeof mock.fn>;
 
   const mockLocation: Location = {
     id: 1,
@@ -21,21 +24,14 @@ describe("LocationsApi", () => {
   };
 
   beforeEach(() => {
-    client = new HetznerClient(mockToken);
-    locations = new LocationsApi(client);
-    fetchMock = mock.fn();
-    mock.method(globalThis, "fetch", fetchMock);
+    ctx = setupMockClient();
+    locations = new LocationsApi(ctx.client);
   });
 
   describe("get", () => {
     it("retrieves a location by id", async () => {
-      fetchMock.mock.mockImplementation(() =>
-        Promise.resolve(
-          new Response(JSON.stringify({ location: mockLocation }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        )
+      ctx.fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(mockResponse({ location: mockLocation }))
       );
 
       const location = await locations.get(1);
@@ -48,27 +44,8 @@ describe("LocationsApi", () => {
 
   describe("list", () => {
     it("lists all locations", async () => {
-      const response = {
-        locations: [mockLocation],
-        meta: {
-          pagination: {
-            page: 1,
-            per_page: 25,
-            previous_page: null,
-            next_page: null,
-            last_page: 1,
-            total_entries: 1,
-          },
-        },
-      };
-
-      fetchMock.mock.mockImplementation(() =>
-        Promise.resolve(
-          new Response(JSON.stringify(response), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        )
+      ctx.fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(mockResponse(mockPaginatedResponse("locations", [mockLocation])))
       );
 
       const result = await locations.list();
@@ -79,27 +56,8 @@ describe("LocationsApi", () => {
 
   describe("getByName", () => {
     it("finds location by name", async () => {
-      const response = {
-        locations: [mockLocation],
-        meta: {
-          pagination: {
-            page: 1,
-            per_page: 25,
-            previous_page: null,
-            next_page: null,
-            last_page: 1,
-            total_entries: 1,
-          },
-        },
-      };
-
-      fetchMock.mock.mockImplementation(() =>
-        Promise.resolve(
-          new Response(JSON.stringify(response), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        )
+      ctx.fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(mockResponse(mockPaginatedResponse("locations", [mockLocation])))
       );
 
       const location = await locations.getByName("fsn1");

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,84 @@
+import { mock } from "node:test";
+import { HetznerClient } from "./client.ts";
+
+/** Mock token used for testing */
+export const MOCK_TOKEN = "test-api-token";
+
+/**
+ * Creates a mock Response for testing API calls.
+ * @param body - The response body (will be JSON stringified)
+ * @param status - HTTP status code (default: 200)
+ * @param headers - Additional headers
+ */
+export function mockResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+/**
+ * Creates a mock paginated response.
+ * @param key - The key for the items array (e.g., "servers")
+ * @param items - The items to include
+ * @param page - Current page number (default: 1)
+ * @param totalEntries - Total entries (default: items.length)
+ */
+export function mockPaginatedResponse(
+  key: string,
+  items: unknown[],
+  page = 1,
+  totalEntries = items.length
+): unknown {
+  return {
+    [key]: items,
+    meta: {
+      pagination: {
+        page,
+        per_page: 25,
+        previous_page: page > 1 ? page - 1 : null,
+        next_page: null,
+        last_page: 1,
+        total_entries: totalEntries,
+      },
+    },
+  };
+}
+
+export type FetchMock = ReturnType<typeof mock.fn>;
+
+export interface TestContext {
+  client: HetznerClient;
+  fetchMock: FetchMock;
+}
+
+/**
+ * Sets up a mock client and fetch mock for testing.
+ * Call this in beforeEach and use the returned objects.
+ *
+ * @example
+ * ```typescript
+ * let ctx: TestContext;
+ *
+ * beforeEach(() => {
+ *   ctx = setupMockClient();
+ * });
+ *
+ * it("does something", async () => {
+ *   ctx.fetchMock.mock.mockImplementation(() =>
+ *     Promise.resolve(mockResponse({ data: "test" }))
+ *   );
+ *   // use ctx.client
+ * });
+ * ```
+ */
+export function setupMockClient(): TestContext {
+  const client = new HetznerClient(MOCK_TOKEN);
+  const fetchMock: FetchMock = mock.fn();
+  mock.method(globalThis, "fetch", fetchMock);
+  return { client, fetchMock };
+}


### PR DESCRIPTION
## Summary
Add shared test utilities module to reduce boilerplate in test files.

## New utilities in `src/test-utils.ts`:
- `MOCK_TOKEN` - Constant for test token
- `mockResponse(body, status, headers)` - Creates mock Response objects
- `mockPaginatedResponse(key, items, page, totalEntries)` - Creates paginated responses
- `setupMockClient()` - Sets up HetznerClient and fetch mock
- `TestContext` - Type for test context

## Example usage
```typescript
let ctx: TestContext;

beforeEach(() => {
  ctx = setupMockClient();
});

it("does something", async () => {
  ctx.fetchMock.mock.mockImplementation(() =>
    Promise.resolve(mockResponse(mockPaginatedResponse("locations", [mockLocation])))
  );
  // use ctx.client
});
```

## Refactored files
- `locations.test.ts` - Refactored as proof of concept

## Test plan
- [x] All tests pass
- [x] Linting passes  
- [x] Type checking passes

Closes #49