### PR TITLE
Add Zones API for Hetzner DNS

### DIFF
--- a/src/dns/zones.test.ts
+++ b/src/dns/zones.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { HetznerDnsClient } from "./client.ts";
+import { ZonesApi, type Zone } from "./zones.ts";
+
+describe("ZonesApi", () => {
+  const mockToken = "test-dns-api-token";
+  let client: HetznerDnsClient;
+  let zones: ZonesApi;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  const mockZone: Zone = {
+    id: "zone-123",
+    name: "example.com",
+    ttl: 3600,
+    ns: ["hydrogen.ns.hetzner.com", "oxygen.ns.hetzner.com", "helium.ns.hetzner.de"],
+    records_count: 4,
+    created: "2025-01-01T00:00:00+00:00",
+    modified: "2025-01-01T00:00:00+00:00",
+    status: "verified",
+  };
+
+  beforeEach(() => {
+    client = new HetznerDnsClient(mockToken);
+    zones = new ZonesApi(client);
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("get", () => {
+    it("retrieves a zone by id", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ zone: mockZone }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const zone = await zones.get("zone-123");
+
+      assert.strictEqual(zone.id, "zone-123");
+      assert.strictEqual(zone.name, "example.com");
+      assert.strictEqual(zone.ttl, 3600);
+    });
+  });
+
+  describe("list", () => {
+    it("lists all zones with pagination", async () => {
+      const response = {
+        zones: [mockZone],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await zones.list();
+
+      assert.strictEqual(result.zones.length, 1);
+      assert.strictEqual(result.zones[0].name, "example.com");
+    });
+
+    it("filters zones by name", async () => {
+      const response = {
+        zones: [mockZone],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      await zones.list({ name: "example.com" });
+
+      const call = fetchMock.mock.calls[0];
+      const url = call?.arguments[0] as string;
+      assert.ok(url.includes("name=example.com"));
+    });
+  });
+
+  describe("create", () => {
+    it("creates a new zone", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ zone: mockZone }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const zone = await zones.create({ name: "example.com", ttl: 3600 });
+
+      assert.strictEqual(zone.name, "example.com");
+      assert.strictEqual(zone.ttl, 3600);
+    });
+  });
+
+  describe("update", () => {
+    it("updates a zone", async () => {
+      const updatedZone = { ...mockZone, ttl: 7200 };
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ zone: updatedZone }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const zone = await zones.update("zone-123", { ttl: 7200 });
+
+      assert.strictEqual(zone.ttl, 7200);
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a zone", async () => {
+      fetchMock.mock.mockImplementation(() => Promise.resolve(new Response("", { status: 200 })));
+
+      await zones.delete("zone-123");
+
+      assert.strictEqual(fetchMock.mock.callCount(), 1);
+      const call = fetchMock.mock.calls[0];
+      const url = call?.arguments[0] as string;
+      const options = call?.arguments[1] as RequestInit;
+      assert.ok(url.includes("/zones/zone-123"));
+      assert.strictEqual(options.method, "DELETE");
+    });
+  });
+
+  describe("getByName", () => {
+    it("finds zone by name", async () => {
+      const response = {
+        zones: [mockZone],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const zone = await zones.getByName("example.com");
+
+      assert.strictEqual(zone?.name, "example.com");
+    });
+
+    it("returns undefined when zone not found", async () => {
+      const response = {
+        zones: [],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 0,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const zone = await zones.getByName("nonexistent.com");
+
+      assert.strictEqual(zone, undefined);
+    });
+  });
+});

--- a/src/dns/zones.ts
+++ b/src/dns/zones.ts
@@ -1,0 +1,162 @@
+import { HetznerDnsClient, type DnsQueryParams } from "./client.ts";
+
+/**
+ * DNS zone status.
+ */
+export type ZoneStatus = "verified" | "failed" | "pending";
+
+/**
+ * Represents a DNS zone.
+ */
+export interface Zone {
+  /** Unique identifier for the zone */
+  id: string;
+  /** Domain name of the zone */
+  name: string;
+  /** Default TTL for records in this zone */
+  ttl: number;
+  /** Name servers for this zone */
+  ns: string[];
+  /** Number of DNS records in this zone */
+  records_count: number;
+  /** ISO 8601 timestamp of when the zone was created */
+  created: string;
+  /** ISO 8601 timestamp of when the zone was last modified */
+  modified: string;
+  /** Current status of the zone */
+  status: ZoneStatus;
+}
+
+/**
+ * Pagination metadata for DNS API responses.
+ */
+export interface DnsPagination {
+  page: number;
+  per_page: number;
+  previous_page: number | null;
+  next_page: number | null;
+  last_page: number;
+  total_entries: number;
+}
+
+/**
+ * Parameters for listing zones.
+ */
+export interface ZonesListParams extends DnsQueryParams {
+  /** Filter zones by name */
+  name?: string;
+  /** Page number (1-indexed) */
+  page?: number;
+  /** Number of items per page */
+  per_page?: number;
+}
+
+/**
+ * Response from the list zones endpoint.
+ */
+export interface ZonesListResponse {
+  zones: Zone[];
+  meta: {
+    pagination: DnsPagination;
+  };
+}
+
+/**
+ * Parameters for creating a zone.
+ */
+export interface ZoneCreateParams {
+  /** Domain name for the zone */
+  name: string;
+  /** Default TTL for records (optional) */
+  ttl?: number;
+}
+
+/**
+ * Parameters for updating a zone.
+ */
+export interface ZoneUpdateParams {
+  /** New domain name (optional) */
+  name?: string;
+  /** New default TTL (optional) */
+  ttl?: number;
+}
+
+/**
+ * API for managing DNS zones.
+ *
+ * @example
+ * ```typescript
+ * const zones = new ZonesApi(client);
+ *
+ * // List all zones
+ * const { zones: allZones } = await zones.list();
+ *
+ * // Create a new zone
+ * const zone = await zones.create({ name: "example.com", ttl: 3600 });
+ *
+ * // Get a zone by name
+ * const existingZone = await zones.getByName("example.com");
+ * ```
+ */
+export class ZonesApi {
+  constructor(private readonly client: HetznerDnsClient) {}
+
+  /**
+   * Retrieves a zone by its ID.
+   * @param id - The zone ID
+   * @returns The zone
+   * @throws {HetznerDnsError} When the zone is not found
+   */
+  async get(id: string): Promise<Zone> {
+    const response = await this.client.get<{ zone: Zone }>(`/zones/${id}`);
+    return response.zone;
+  }
+
+  /**
+   * Lists all zones with optional filtering.
+   * @param params - Optional query parameters
+   * @returns Paginated list of zones
+   */
+  async list(params: ZonesListParams = {}): Promise<ZonesListResponse> {
+    return this.client.get<ZonesListResponse>("/zones", params);
+  }
+
+  /**
+   * Creates a new zone.
+   * @param params - Zone creation parameters
+   * @returns The created zone
+   */
+  async create(params: ZoneCreateParams): Promise<Zone> {
+    const response = await this.client.post<{ zone: Zone }>("/zones", params);
+    return response.zone;
+  }
+
+  /**
+   * Updates an existing zone.
+   * @param id - The zone ID
+   * @param params - Zone update parameters
+   * @returns The updated zone
+   */
+  async update(id: string, params: ZoneUpdateParams): Promise<Zone> {
+    const response = await this.client.put<{ zone: Zone }>(`/zones/${id}`, params);
+    return response.zone;
+  }
+
+  /**
+   * Deletes a zone.
+   * @param id - The zone ID
+   */
+  async delete(id: string): Promise<void> {
+    await this.client.delete(`/zones/${id}`);
+  }
+
+  /**
+   * Finds a zone by its domain name.
+   * @param name - The domain name to search for
+   * @returns The zone if found, undefined otherwise
+   */
+  async getByName(name: string): Promise<Zone | undefined> {
+    const response = await this.list({ name });
+    return response.zones[0];
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `ZonesApi` class for managing DNS zones
- Full CRUD operations (list, get, create, update, delete)
- Helper method `getByName` for looking up zones by domain name
- Comprehensive JSDoc documentation
- Full test coverage

## Test plan
- [x] All existing tests pass (209 tests)
- [x] New Zones API tests pass
- [x] Linting passes
- [x] TypeScript type checking passes
- [x] Formatting passes

Closes #53