### PR TITLE
Add Records API for Hetzner DNS

### DIFF
--- a/src/dns/records.test.ts
+++ b/src/dns/records.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { HetznerDnsClient } from "./client.ts";
+import { RecordsApi, type Record } from "./records.ts";
+
+describe("RecordsApi", () => {
+  const mockToken = "test-dns-api-token";
+  let client: HetznerDnsClient;
+  let records: RecordsApi;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  const mockRecord: Record = {
+    id: "record-123",
+    zone_id: "zone-456",
+    type: "A",
+    name: "@",
+    value: "192.168.1.1",
+    ttl: 3600,
+    created: "2025-01-01T00:00:00+00:00",
+    modified: "2025-01-01T00:00:00+00:00",
+  };
+
+  beforeEach(() => {
+    client = new HetznerDnsClient(mockToken);
+    records = new RecordsApi(client);
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("get", () => {
+    it("retrieves a record by id", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ record: mockRecord }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const record = await records.get("record-123");
+
+      assert.strictEqual(record.id, "record-123");
+      assert.strictEqual(record.type, "A");
+      assert.strictEqual(record.value, "192.168.1.1");
+    });
+  });
+
+  describe("list", () => {
+    it("lists all records for a zone", async () => {
+      const response = {
+        records: [mockRecord],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await records.list({ zone_id: "zone-456" });
+
+      assert.strictEqual(result.records.length, 1);
+      assert.strictEqual(result.records[0].type, "A");
+    });
+
+    it("filters records by type", async () => {
+      const response = {
+        records: [mockRecord],
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: 25,
+            previous_page: null,
+            next_page: null,
+            last_page: 1,
+            total_entries: 1,
+          },
+        },
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      await records.list({ zone_id: "zone-456", type: "A" });
+
+      const call = fetchMock.mock.calls[0];
+      const url = call?.arguments[0] as string;
+      assert.ok(url.includes("zone_id=zone-456"));
+      assert.ok(url.includes("type=A"));
+    });
+  });
+
+  describe("create", () => {
+    it("creates a new record", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ record: mockRecord }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const record = await records.create({
+        zone_id: "zone-456",
+        type: "A",
+        name: "@",
+        value: "192.168.1.1",
+        ttl: 3600,
+      });
+
+      assert.strictEqual(record.type, "A");
+      assert.strictEqual(record.value, "192.168.1.1");
+    });
+  });
+
+  describe("update", () => {
+    it("updates a record", async () => {
+      const updatedRecord = { ...mockRecord, value: "192.168.1.2" };
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ record: updatedRecord }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const record = await records.update("record-123", {
+        zone_id: "zone-456",
+        type: "A",
+        name: "@",
+        value: "192.168.1.2",
+        ttl: 3600,
+      });
+
+      assert.strictEqual(record.value, "192.168.1.2");
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a record", async () => {
+      fetchMock.mock.mockImplementation(() => Promise.resolve(new Response("", { status: 200 })));
+
+      await records.delete("record-123");
+
+      assert.strictEqual(fetchMock.mock.callCount(), 1);
+      const call = fetchMock.mock.calls[0];
+      const url = call?.arguments[0] as string;
+      const options = call?.arguments[1] as RequestInit;
+      assert.ok(url.includes("/records/record-123"));
+      assert.strictEqual(options.method, "DELETE");
+    });
+  });
+
+  describe("bulkCreate", () => {
+    it("creates multiple records at once", async () => {
+      const response = {
+        records: [mockRecord, { ...mockRecord, id: "record-124", name: "www" }],
+        valid_records: [mockRecord, { ...mockRecord, id: "record-124", name: "www" }],
+        invalid_records: [],
+      };
+
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await records.bulkCreate({
+        records: [
+          { zone_id: "zone-456", type: "A", name: "@", value: "192.168.1.1", ttl: 3600 },
+          { zone_id: "zone-456", type: "A", name: "www", value: "192.168.1.1", ttl: 3600 },
+        ],
+      });
+
+      assert.strictEqual(result.records.length, 2);
+      assert.strictEqual(result.valid_records.length, 2);
+      assert.strictEqual(result.invalid_records.length, 0);
+    });
+  });
+});

--- a/src/dns/records.ts
+++ b/src/dns/records.ts
@@ -1,0 +1,209 @@
+import { HetznerDnsClient, type DnsQueryParams } from "./client.ts";
+import { type DnsPagination } from "./zones.ts";
+
+/**
+ * DNS record types supported by Hetzner DNS.
+ */
+export type RecordType =
+  | "A"
+  | "AAAA"
+  | "CNAME"
+  | "MX"
+  | "NS"
+  | "TXT"
+  | "SRV"
+  | "CAA"
+  | "TLSA"
+  | "DS"
+  | "SOA"
+  | "PTR";
+
+/**
+ * Represents a DNS record.
+ */
+export interface Record {
+  /** Unique identifier for the record */
+  id: string;
+  /** ID of the zone this record belongs to */
+  zone_id: string;
+  /** Record type (A, AAAA, CNAME, etc.) */
+  type: RecordType;
+  /** Record name (use @ for root) */
+  name: string;
+  /** Record value */
+  value: string;
+  /** Time to live in seconds */
+  ttl?: number;
+  /** ISO 8601 timestamp of when the record was created */
+  created: string;
+  /** ISO 8601 timestamp of when the record was last modified */
+  modified: string;
+}
+
+/**
+ * Parameters for listing records.
+ */
+export interface RecordsListParams extends DnsQueryParams {
+  /** Filter records by zone ID (required) */
+  zone_id: string;
+  /** Filter records by type */
+  type?: RecordType;
+  /** Filter records by name */
+  name?: string;
+  /** Page number (1-indexed) */
+  page?: number;
+  /** Number of items per page */
+  per_page?: number;
+}
+
+/**
+ * Response from the list records endpoint.
+ */
+export interface RecordsListResponse {
+  records: Record[];
+  meta: {
+    pagination: DnsPagination;
+  };
+}
+
+/**
+ * Parameters for creating a record.
+ */
+export interface RecordCreateParams {
+  /** ID of the zone to create the record in */
+  zone_id: string;
+  /** Record type */
+  type: RecordType;
+  /** Record name (use @ for root) */
+  name: string;
+  /** Record value */
+  value: string;
+  /** Time to live in seconds (optional) */
+  ttl?: number;
+}
+
+/**
+ * Parameters for updating a record.
+ */
+export interface RecordUpdateParams {
+  /** ID of the zone */
+  zone_id: string;
+  /** Record type */
+  type: RecordType;
+  /** Record name */
+  name: string;
+  /** Record value */
+  value: string;
+  /** Time to live in seconds (optional) */
+  ttl?: number;
+}
+
+/**
+ * Parameters for bulk creating records.
+ */
+export interface RecordsBulkCreateParams {
+  /** Array of records to create */
+  records: RecordCreateParams[];
+}
+
+/**
+ * Response from bulk create endpoint.
+ */
+export interface RecordsBulkCreateResponse {
+  /** All records that were processed */
+  records: Record[];
+  /** Records that were successfully created */
+  valid_records: Record[];
+  /** Records that failed validation */
+  invalid_records: Record[];
+}
+
+/**
+ * API for managing DNS records.
+ *
+ * @example
+ * ```typescript
+ * const records = new RecordsApi(client);
+ *
+ * // List all records in a zone
+ * const { records: allRecords } = await records.list({ zone_id: "zone-123" });
+ *
+ * // Create an A record
+ * const record = await records.create({
+ *   zone_id: "zone-123",
+ *   type: "A",
+ *   name: "www",
+ *   value: "192.168.1.1",
+ *   ttl: 3600,
+ * });
+ *
+ * // Bulk create records
+ * const result = await records.bulkCreate({
+ *   records: [
+ *     { zone_id: "zone-123", type: "A", name: "@", value: "192.168.1.1", ttl: 3600 },
+ *     { zone_id: "zone-123", type: "A", name: "www", value: "192.168.1.1", ttl: 3600 },
+ *   ],
+ * });
+ * ```
+ */
+export class RecordsApi {
+  constructor(private readonly client: HetznerDnsClient) {}
+
+  /**
+   * Retrieves a record by its ID.
+   * @param id - The record ID
+   * @returns The record
+   * @throws {HetznerDnsError} When the record is not found
+   */
+  async get(id: string): Promise<Record> {
+    const response = await this.client.get<{ record: Record }>(`/records/${id}`);
+    return response.record;
+  }
+
+  /**
+   * Lists all records with optional filtering.
+   * @param params - Query parameters (zone_id is required)
+   * @returns Paginated list of records
+   */
+  async list(params: RecordsListParams): Promise<RecordsListResponse> {
+    return this.client.get<RecordsListResponse>("/records", params);
+  }
+
+  /**
+   * Creates a new record.
+   * @param params - Record creation parameters
+   * @returns The created record
+   */
+  async create(params: RecordCreateParams): Promise<Record> {
+    const response = await this.client.post<{ record: Record }>("/records", params);
+    return response.record;
+  }
+
+  /**
+   * Updates an existing record.
+   * @param id - The record ID
+   * @param params - Record update parameters
+   * @returns The updated record
+   */
+  async update(id: string, params: RecordUpdateParams): Promise<Record> {
+    const response = await this.client.put<{ record: Record }>(`/records/${id}`, params);
+    return response.record;
+  }
+
+  /**
+   * Deletes a record.
+   * @param id - The record ID
+   */
+  async delete(id: string): Promise<void> {
+    await this.client.delete(`/records/${id}`);
+  }
+
+  /**
+   * Creates multiple records at once.
+   * @param params - Bulk create parameters containing array of records
+   * @returns Result containing valid and invalid records
+   */
+  async bulkCreate(params: RecordsBulkCreateParams): Promise<RecordsBulkCreateResponse> {
+    return this.client.post<RecordsBulkCreateResponse>("/records/bulk", params);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `RecordsApi` class for managing DNS records
- Full CRUD operations plus bulk create
- Supports all DNS record types (A, AAAA, CNAME, MX, NS, TXT, SRV, CAA, TLSA, DS, SOA, PTR)
- Comprehensive JSDoc documentation
- Full test coverage

## Test plan
- [x] All existing tests pass (216 tests)
- [x] New Records API tests pass
- [x] Linting passes
- [x] TypeScript type checking passes
- [x] Formatting passes

Closes #55