### PR TITLE
Add HetznerDns unified SDK

### DIFF
--- a/src/dns/hetzner-dns.test.ts
+++ b/src/dns/hetzner-dns.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { HetznerDns } from "./hetzner-dns.ts";
+import { HetznerDnsClient } from "./client.ts";
+import { ZonesApi } from "./zones.ts";
+import { RecordsApi } from "./records.ts";
+
+describe("HetznerDns", () => {
+  const mockToken = "test-dns-api-token";
+
+  describe("constructor", () => {
+    it("creates an instance with all resource APIs", () => {
+      const dns = new HetznerDns(mockToken);
+
+      assert.ok(dns.client instanceof HetznerDnsClient);
+      assert.ok(dns.zones instanceof ZonesApi);
+      assert.ok(dns.records instanceof RecordsApi);
+    });
+
+    it("accepts custom options", () => {
+      const dns = new HetznerDns(mockToken, {
+        baseUrl: "https://custom.dns.api/v1",
+      });
+
+      assert.strictEqual(dns.client.baseUrl, "https://custom.dns.api/v1");
+    });
+
+    it("exposes the underlying client", () => {
+      const dns = new HetznerDns(mockToken);
+
+      assert.strictEqual(dns.client.baseUrl, "https://dns.hetzner.com/api/v1");
+    });
+  });
+});

--- a/src/dns/hetzner-dns.ts
+++ b/src/dns/hetzner-dns.ts
@@ -1,0 +1,49 @@
+import { HetznerDnsClient, type HetznerDnsClientOptions } from "./client.ts";
+import { ZonesApi } from "./zones.ts";
+import { RecordsApi } from "./records.ts";
+
+/**
+ * Unified SDK for the Hetzner DNS API.
+ * Provides access to all DNS resource APIs through a single entry point.
+ *
+ * @example
+ * ```typescript
+ * const dns = new HetznerDns("your-dns-api-token");
+ *
+ * // List all zones
+ * const { zones } = await dns.zones.list();
+ *
+ * // Get records for a zone
+ * const { records } = await dns.records.list({ zone_id: zones[0].id });
+ *
+ * // Create a new record
+ * const record = await dns.records.create({
+ *   zone_id: zones[0].id,
+ *   type: "A",
+ *   name: "www",
+ *   value: "192.168.1.1",
+ *   ttl: 3600,
+ * });
+ * ```
+ */
+export class HetznerDns {
+  /** The underlying HTTP client */
+  readonly client: HetznerDnsClient;
+
+  /** API for managing DNS zones */
+  readonly zones: ZonesApi;
+
+  /** API for managing DNS records */
+  readonly records: RecordsApi;
+
+  /**
+   * Creates a new Hetzner DNS SDK instance.
+   * @param token - Your Hetzner DNS API token (not the Cloud API token)
+   * @param options - Optional configuration options
+   */
+  constructor(token: string, options: HetznerDnsClientOptions = {}) {
+    this.client = new HetznerDnsClient(token, options);
+    this.zones = new ZonesApi(this.client);
+    this.records = new RecordsApi(this.client);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `HetznerDns` class as unified entry point for DNS operations
- Provides access to zones and records APIs through a single instance
- Comprehensive JSDoc documentation with usage examples

## Test plan
- [x] All tests pass (219 tests)
- [x] Linting passes
- [x] TypeScript type checking passes
- [x] Formatting passes

Closes #57