### PR TITLE
Export DNS types and classes from index.ts

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,40 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { VERSION } from "./index.ts";
+import {
+  VERSION,
+  HetznerDns,
+  HetznerDnsClient,
+  HetznerDnsError,
+  DnsRateLimitError,
+  ZonesApi,
+  RecordsApi,
+} from "./index.ts";
 
 describe("hetzner client", () => {
   it("exports VERSION", () => {
     assert.strictEqual(VERSION, "0.1.0");
+  });
+});
+
+describe("DNS exports", () => {
+  it("exports HetznerDns SDK", () => {
+    const dns = new HetznerDns("test-token");
+    assert.ok(dns instanceof HetznerDns);
+    assert.ok(dns.zones instanceof ZonesApi);
+    assert.ok(dns.records instanceof RecordsApi);
+  });
+
+  it("exports HetznerDnsClient", () => {
+    const client = new HetznerDnsClient("test-token");
+    assert.ok(client instanceof HetznerDnsClient);
+  });
+
+  it("exports DNS error classes", () => {
+    const error = new HetznerDnsError("test", 0, 404);
+    assert.ok(error instanceof HetznerDnsError);
+
+    const rateLimitError = new DnsRateLimitError("test", 0, 60);
+    assert.ok(rateLimitError instanceof DnsRateLimitError);
+    assert.ok(rateLimitError instanceof HetznerDnsError);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,3 +219,32 @@ export type {
   VolumePricing,
   VolumeLocationPricing,
 } from "./resources/pricing.ts";
+
+// DNS API exports
+export { HetznerDns } from "./dns/hetzner-dns.ts";
+
+export { HetznerDnsClient, HetznerDnsError, DnsRateLimitError } from "./dns/client.ts";
+export type { HetznerDnsClientOptions, DnsQueryParams } from "./dns/client.ts";
+
+export { ZonesApi } from "./dns/zones.ts";
+export type {
+  Zone,
+  ZoneStatus,
+  ZonesListParams,
+  ZonesListResponse,
+  ZoneCreateParams,
+  ZoneUpdateParams,
+  DnsPagination,
+} from "./dns/zones.ts";
+
+export { RecordsApi } from "./dns/records.ts";
+export type {
+  Record,
+  RecordType,
+  RecordsListParams,
+  RecordsListResponse,
+  RecordCreateParams,
+  RecordUpdateParams,
+  RecordsBulkCreateParams,
+  RecordsBulkCreateResponse,
+} from "./dns/records.ts";


### PR DESCRIPTION
## Summary
- Exports all DNS-related APIs and types from the main index.ts
- Adds tests to verify DNS exports work correctly
- Users can now import DNS classes directly from the package

## Usage
```typescript
import { HetznerDns, HetznerDnsClient, ZonesApi, RecordsApi } from "hetzner";
```

## Test plan
- [x] All tests pass (222 tests)
- [x] Linting passes
- [x] TypeScript type checking passes
- [x] Formatting passes

Closes #59