### PR TITLE
refactor: extract shared BaseHttpClient class

### DIFF
--- a/src/base-client.test.ts
+++ b/src/base-client.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { BaseHttpClient, type QueryParams } from "./base-client.ts";
+
+// Concrete implementation for testing
+class TestClient extends BaseHttpClient {
+  public lastAuthHeaders: Record<string, string> | null = null;
+  public errorToThrow: Error | null = null;
+
+  constructor(token: string, baseUrl = "https://test.api.com") {
+    super(token, baseUrl);
+  }
+
+  protected getAuthHeaders(): Record<string, string> {
+    this.lastAuthHeaders = { "X-Test-Token": this.token };
+    return this.lastAuthHeaders;
+  }
+
+  protected handleError(response: Response): Promise<never> {
+    if (this.errorToThrow) {
+      return Promise.reject(this.errorToThrow);
+    }
+    return Promise.reject(new Error(`HTTP ${String(response.status)}`));
+  }
+}
+
+describe("BaseHttpClient", () => {
+  let client: TestClient;
+  let fetchMock: ReturnType<typeof mock.fn>;
+
+  beforeEach(() => {
+    client = new TestClient("test-token");
+    fetchMock = mock.fn();
+    mock.method(globalThis, "fetch", fetchMock);
+  });
+
+  describe("constructor", () => {
+    it("uses provided base URL", () => {
+      const customClient = new TestClient("token", "https://custom.api.com");
+      assert.strictEqual(customClient.baseUrl, "https://custom.api.com");
+    });
+
+    it("allows base URL override via options", () => {
+      const customClient = new TestClient("token", "https://default.api.com");
+      // BaseClientOptions allows baseUrl override - tested via HetznerClient
+      assert.strictEqual(customClient.baseUrl, "https://default.api.com");
+    });
+  });
+
+  describe("HTTP methods", () => {
+    it("makes GET requests with auth headers", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ data: "test" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      await client.get("/test");
+
+      assert.strictEqual(fetchMock.mock.callCount(), 1);
+      const call = fetchMock.mock.calls[0];
+      const url = call?.arguments[0] as string;
+      const options = call?.arguments[1] as RequestInit;
+      const headers = options.headers as Record<string, string>;
+
+      assert.strictEqual(url, "https://test.api.com/test");
+      assert.strictEqual(options.method, "GET");
+      assert.strictEqual(headers["X-Test-Token"], "test-token");
+    });
+
+    it("makes POST requests with JSON body", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ result: "ok" }), {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const body = { name: "test" };
+      await client.post("/test", body);
+
+      const call = fetchMock.mock.calls[0];
+      const options = call?.arguments[1] as RequestInit;
+      const headers = options.headers as Record<string, string>;
+
+      assert.strictEqual(options.method, "POST");
+      assert.strictEqual(headers["Content-Type"], "application/json");
+      assert.strictEqual(options.body, JSON.stringify(body));
+    });
+
+    it("makes PUT requests", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      await client.put("/test", { key: "value" });
+
+      const [, options] = fetchMock.mock.calls[0]?.arguments ?? [];
+      assert.strictEqual(options.method, "PUT");
+    });
+
+    it("makes DELETE requests", async () => {
+      fetchMock.mock.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      const result = await client.delete("/test");
+
+      const [, options] = fetchMock.mock.calls[0]?.arguments ?? [];
+      assert.strictEqual(options.method, "DELETE");
+      assert.strictEqual(result, undefined);
+    });
+  });
+
+  describe("query parameters", () => {
+    it("appends query parameters to URL", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      await client.get("/test", { page: 1, limit: 10 });
+
+      const [url] = fetchMock.mock.calls[0]?.arguments ?? [];
+      assert.strictEqual(url, "https://test.api.com/test?page=1&limit=10");
+    });
+
+    it("handles array query parameters", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      await client.get("/test", { ids: [1, 2, 3] });
+
+      const [url] = fetchMock.mock.calls[0]?.arguments ?? [];
+      assert.strictEqual(url, "https://test.api.com/test?ids=1&ids=2&ids=3");
+    });
+
+    it("ignores undefined parameters", async () => {
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const params: QueryParams = { page: 1, filter: undefined };
+      await client.get("/test", params);
+
+      const [url] = fetchMock.mock.calls[0]?.arguments ?? [];
+      assert.strictEqual(url, "https://test.api.com/test?page=1");
+    });
+  });
+
+  describe("response handling", () => {
+    it("returns undefined for 204 No Content", async () => {
+      fetchMock.mock.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      const result = await client.get("/test");
+
+      assert.strictEqual(result, undefined);
+    });
+
+    it("parses JSON response", async () => {
+      const responseData = { items: [1, 2, 3] };
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(responseData), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const result = await client.get<{ items: number[] }>("/test");
+
+      assert.deepStrictEqual(result, responseData);
+    });
+  });
+
+  describe("error handling", () => {
+    it("calls handleError for non-ok responses", async () => {
+      client.errorToThrow = new Error("Custom error");
+      fetchMock.mock.mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify({ error: "test" }), { status: 404 }))
+      );
+
+      await assert.rejects(() => client.get("/test"), { message: "Custom error" });
+    });
+  });
+});

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -1,0 +1,155 @@
+type QueryValue = string | number | boolean | string[] | number[];
+
+/**
+ * Query parameters for API requests.
+ */
+export type QueryParams = Record<string, QueryValue | undefined>;
+
+/**
+ * Configuration options for HTTP clients.
+ */
+export interface BaseClientOptions {
+  /** Base URL for the API */
+  baseUrl?: string;
+}
+
+/**
+ * Abstract base class for HTTP clients.
+ * Provides common HTTP functionality with customizable authentication and error handling.
+ */
+export abstract class BaseHttpClient {
+  /** The base URL for API requests */
+  public readonly baseUrl: string;
+  protected readonly token: string;
+
+  /**
+   * Creates a new HTTP client.
+   * @param token - API token for authentication
+   * @param defaultBaseUrl - Default base URL if not provided in options
+   * @param options - Optional configuration options
+   */
+  constructor(token: string, defaultBaseUrl: string, options: BaseClientOptions = {}) {
+    this.token = token;
+    this.baseUrl = options.baseUrl ?? defaultBaseUrl;
+  }
+
+  /**
+   * Returns the authentication headers for this client.
+   * Must be implemented by subclasses.
+   */
+  protected abstract getAuthHeaders(): Record<string, string>;
+
+  /**
+   * Handles error responses from the API.
+   * Must be implemented by subclasses.
+   */
+  protected abstract handleError(response: Response): Promise<never>;
+
+  /**
+   * Parses a successful response.
+   * Can be overridden by subclasses for custom parsing behavior.
+   */
+  protected async parseResponse<T>(response: Response): Promise<T> {
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return (await response.json()) as T;
+  }
+
+  /**
+   * Performs a GET request to the API.
+   * @param path - The API endpoint path
+   * @param params - Optional query parameters
+   * @returns The parsed JSON response
+   */
+  async get<T>(path: string, params?: QueryParams): Promise<T> {
+    return this.request<T>("GET", path, undefined, params);
+  }
+
+  /**
+   * Performs a POST request to the API.
+   * @param path - The API endpoint path
+   * @param body - Optional request body (will be JSON-encoded)
+   * @returns The parsed JSON response
+   */
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+
+  /**
+   * Performs a PUT request to the API.
+   * @param path - The API endpoint path
+   * @param body - Optional request body (will be JSON-encoded)
+   * @returns The parsed JSON response
+   */
+  async put<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PUT", path, body);
+  }
+
+  /**
+   * Performs a DELETE request to the API.
+   * @param path - The API endpoint path
+   * @returns The parsed JSON response, or undefined for empty responses
+   */
+  async delete<T>(path: string): Promise<T | undefined> {
+    return this.request<T>("DELETE", path);
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    params?: QueryParams
+  ): Promise<T> {
+    const url = this.buildUrl(path, params);
+
+    const headers: Record<string, string> = {
+      ...this.getAuthHeaders(),
+    };
+
+    const init: RequestInit = {
+      method,
+      headers,
+    };
+
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      init.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, init);
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    return this.parseResponse<T>(response);
+  }
+
+  /**
+   * Builds a URL with query parameters.
+   * @param path - The API endpoint path
+   * @param params - Optional query parameters
+   * @returns The full URL string
+   */
+  protected buildUrl(path: string, params?: QueryParams): string {
+    const fullPath = this.baseUrl + path;
+    const url = new URL(fullPath);
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) continue;
+
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            url.searchParams.append(key, String(item));
+          }
+        } else {
+          url.searchParams.append(key, String(value));
+        }
+      }
+    }
+
+    return url.toString();
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,9 @@
+import { BaseHttpClient, type BaseClientOptions, type QueryParams } from "./base-client.ts";
+
 /**
  * Configuration options for the Hetzner client.
  */
-export interface HetznerClientOptions {
+export interface HetznerClientOptions extends BaseClientOptions {
   /** Base URL for the Hetzner Cloud API. Defaults to https://api.hetzner.cloud/v1 */
   baseUrl?: string;
 }
@@ -45,9 +47,7 @@ export class RateLimitError extends HetznerError {
   }
 }
 
-type QueryValue = string | number | boolean | string[] | number[];
-/** Query parameters for API requests */
-export type QueryParams = Record<string, QueryValue | undefined>;
+export type { QueryParams };
 
 /**
  * HTTP client for communicating with the Hetzner Cloud API.
@@ -58,125 +58,23 @@ export type QueryParams = Record<string, QueryValue | undefined>;
  * const servers = await client.get("/servers");
  * ```
  */
-export class HetznerClient {
-  /** The base URL for API requests */
-  public readonly baseUrl: string;
-  private readonly token: string;
-
+export class HetznerClient extends BaseHttpClient {
   /**
    * Creates a new Hetzner client.
    * @param token - Your Hetzner Cloud API token
    * @param options - Optional configuration options
    */
   constructor(token: string, options: HetznerClientOptions = {}) {
-    this.token = token;
-    this.baseUrl = options.baseUrl ?? "https://api.hetzner.cloud/v1";
+    super(token, "https://api.hetzner.cloud/v1", options);
   }
 
-  /**
-   * Performs a GET request to the API.
-   * @param path - The API endpoint path (e.g., "/servers")
-   * @param params - Optional query parameters
-   * @returns The parsed JSON response
-   * @throws {HetznerError} When the API returns an error
-   * @throws {RateLimitError} When the rate limit is exceeded
-   */
-  async get<T>(path: string, params?: QueryParams): Promise<T> {
-    return this.request<T>("GET", path, undefined, params);
-  }
-
-  /**
-   * Performs a POST request to the API.
-   * @param path - The API endpoint path
-   * @param body - Optional request body (will be JSON-encoded)
-   * @returns The parsed JSON response
-   * @throws {HetznerError} When the API returns an error
-   * @throws {RateLimitError} When the rate limit is exceeded
-   */
-  async post<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>("POST", path, body);
-  }
-
-  /**
-   * Performs a PUT request to the API.
-   * @param path - The API endpoint path
-   * @param body - Optional request body (will be JSON-encoded)
-   * @returns The parsed JSON response
-   * @throws {HetznerError} When the API returns an error
-   * @throws {RateLimitError} When the rate limit is exceeded
-   */
-  async put<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>("PUT", path, body);
-  }
-
-  /**
-   * Performs a DELETE request to the API.
-   * @param path - The API endpoint path
-   * @returns The parsed JSON response, or undefined for 204 responses
-   * @throws {HetznerError} When the API returns an error
-   * @throws {RateLimitError} When the rate limit is exceeded
-   */
-  async delete<T>(path: string): Promise<T | undefined> {
-    return this.request<T>("DELETE", path);
-  }
-
-  private async request<T>(
-    method: string,
-    path: string,
-    body?: unknown,
-    params?: QueryParams
-  ): Promise<T> {
-    const url = this.buildUrl(path, params);
-
-    const headers: Record<string, string> = {
+  protected getAuthHeaders(): Record<string, string> {
+    return {
       Authorization: `Bearer ${this.token}`,
     };
-
-    const init: RequestInit = {
-      method,
-      headers,
-    };
-
-    if (body !== undefined) {
-      headers["Content-Type"] = "application/json";
-      init.body = JSON.stringify(body);
-    }
-
-    const response = await fetch(url, init);
-
-    if (!response.ok) {
-      await this.handleError(response);
-    }
-
-    if (response.status === 204) {
-      return undefined as T;
-    }
-
-    return (await response.json()) as T;
   }
 
-  private buildUrl(path: string, params?: QueryParams): string {
-    const fullPath = this.baseUrl + path;
-    const url = new URL(fullPath);
-
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        if (value === undefined) continue;
-
-        if (Array.isArray(value)) {
-          for (const item of value) {
-            url.searchParams.append(key, String(item));
-          }
-        } else {
-          url.searchParams.append(key, String(value));
-        }
-      }
-    }
-
-    return url.toString();
-  }
-
-  private async handleError(response: Response): Promise<never> {
+  protected async handleError(response: Response): Promise<never> {
     let errorData: ErrorResponse;
 
     try {

--- a/src/dns/client.ts
+++ b/src/dns/client.ts
@@ -1,7 +1,9 @@
+import { BaseHttpClient, type BaseClientOptions, type QueryParams } from "../base-client.ts";
+
 /**
  * Configuration options for the Hetzner DNS client.
  */
-export interface HetznerDnsClientOptions {
+export interface HetznerDnsClientOptions extends BaseClientOptions {
   /** Base URL for the Hetzner DNS API. Defaults to https://dns.hetzner.com/api/v1 */
   baseUrl?: string;
 }
@@ -46,9 +48,8 @@ export class DnsRateLimitError extends HetznerDnsError {
   }
 }
 
-type QueryValue = string | number | boolean | string[] | number[];
 /** Query parameters for DNS API requests */
-export type DnsQueryParams = Record<string, QueryValue | undefined>;
+export type DnsQueryParams = QueryParams;
 
 /**
  * HTTP client for communicating with the Hetzner DNS API.
@@ -62,126 +63,31 @@ export type DnsQueryParams = Record<string, QueryValue | undefined>;
  * const zones = await client.get("/zones");
  * ```
  */
-export class HetznerDnsClient {
-  /** The base URL for DNS API requests */
-  public readonly baseUrl: string;
-  private readonly token: string;
-
+export class HetznerDnsClient extends BaseHttpClient {
   /**
    * Creates a new Hetzner DNS client.
    * @param token - Your Hetzner DNS API token (not the Cloud API token)
    * @param options - Optional configuration options
    */
   constructor(token: string, options: HetznerDnsClientOptions = {}) {
-    this.token = token;
-    this.baseUrl = options.baseUrl ?? "https://dns.hetzner.com/api/v1";
+    super(token, "https://dns.hetzner.com/api/v1", options);
   }
 
-  /**
-   * Performs a GET request to the DNS API.
-   * @param path - The API endpoint path (e.g., "/zones")
-   * @param params - Optional query parameters
-   * @returns The parsed JSON response
-   * @throws {HetznerDnsError} When the API returns an error
-   * @throws {DnsRateLimitError} When the rate limit is exceeded
-   */
-  async get<T>(path: string, params?: DnsQueryParams): Promise<T> {
-    return this.request<T>("GET", path, undefined, params);
-  }
-
-  /**
-   * Performs a POST request to the DNS API.
-   * @param path - The API endpoint path
-   * @param body - Optional request body (will be JSON-encoded)
-   * @returns The parsed JSON response
-   * @throws {HetznerDnsError} When the API returns an error
-   * @throws {DnsRateLimitError} When the rate limit is exceeded
-   */
-  async post<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>("POST", path, body);
-  }
-
-  /**
-   * Performs a PUT request to the DNS API.
-   * @param path - The API endpoint path
-   * @param body - Optional request body (will be JSON-encoded)
-   * @returns The parsed JSON response
-   * @throws {HetznerDnsError} When the API returns an error
-   * @throws {DnsRateLimitError} When the rate limit is exceeded
-   */
-  async put<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>("PUT", path, body);
-  }
-
-  /**
-   * Performs a DELETE request to the DNS API.
-   * @param path - The API endpoint path
-   * @returns The parsed JSON response, or undefined for empty responses
-   * @throws {HetznerDnsError} When the API returns an error
-   * @throws {DnsRateLimitError} When the rate limit is exceeded
-   */
-  async delete<T>(path: string): Promise<T | undefined> {
-    return this.request<T>("DELETE", path);
-  }
-
-  private async request<T>(
-    method: string,
-    path: string,
-    body?: unknown,
-    params?: DnsQueryParams
-  ): Promise<T> {
-    const url = this.buildUrl(path, params);
-
-    const headers: Record<string, string> = {
+  protected getAuthHeaders(): Record<string, string> {
+    return {
       "Auth-API-Token": this.token,
     };
+  }
 
-    const init: RequestInit = {
-      method,
-      headers,
-    };
-
-    if (body !== undefined) {
-      headers["Content-Type"] = "application/json";
-      init.body = JSON.stringify(body);
-    }
-
-    const response = await fetch(url, init);
-
-    if (!response.ok) {
-      await this.handleError(response);
-    }
-
+  protected async parseResponse<T>(response: Response): Promise<T> {
     const text = await response.text();
     if (!text) {
       return undefined as T;
     }
-
     return JSON.parse(text) as T;
   }
 
-  private buildUrl(path: string, params?: DnsQueryParams): string {
-    const fullPath = this.baseUrl + path;
-    const url = new URL(fullPath);
-
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        if (value === undefined) continue;
-
-        if (Array.isArray(value)) {
-          for (const item of value) {
-            url.searchParams.append(key, String(item));
-          }
-        } else {
-          url.searchParams.append(key, String(value));
-        }
-      }
-    }
-
-    return url.toString();
-  }
-
-  private async handleError(response: Response): Promise<never> {
+  protected async handleError(response: Response): Promise<never> {
     let errorMessage = `HTTP ${String(response.status)}: ${response.statusText}`;
     let errorCode = 0;
 


### PR DESCRIPTION
## Summary

- Extract common HTTP client logic into `BaseHttpClient` abstract class
- Refactor both `HetznerClient` and `HetznerDnsClient` to extend the base class
- Reduce code duplication while maintaining backwards compatibility

Closes #64

## Changes

### New Files
- `src/base-client.ts` - Abstract base class with common HTTP functionality
- `src/base-client.test.ts` - Comprehensive tests for the base class

### Modified Files
- `src/client.ts` - Now extends `BaseHttpClient`
- `src/dns/client.ts` - Now extends `BaseHttpClient`

## Design

The base class provides:
- Common HTTP methods (`get`, `post`, `put`, `delete`)
- URL building with query parameter handling
- Request execution with JSON body support

Subclasses customize via abstract/override methods:
- `getAuthHeaders()` - Different auth headers (Bearer vs Auth-API-Token)
- `handleError()` - Different error response formats
- `parseResponse()` - Different empty response handling

## Backwards Compatibility

The public API is unchanged - all existing code will continue to work.