### PR TITLE
fix: read VERSION from package.json

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { createRequire } from "node:module";
 import {
   VERSION,
   HetznerDns,
@@ -10,9 +11,14 @@ import {
   RecordsApi,
 } from "./index.ts";
 
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
 describe("hetzner client", () => {
-  it("exports VERSION", () => {
-    assert.strictEqual(VERSION, "0.1.0");
+  it("exports VERSION matching package.json", () => {
+    assert.strictEqual(VERSION, pkg.version);
+    assert.ok(typeof VERSION === "string");
+    assert.ok(VERSION.length > 0);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-export const VERSION = "0.1.0";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+/** Library version, read from package.json */
+export const VERSION: string = pkg.version;
 
 export { Hetzner } from "./hetzner.ts";
 


### PR DESCRIPTION
## Summary

Read the VERSION constant from package.json instead of hardcoding it, making package.json the single source of truth.

Closes #68

## Changes

- Use `createRequire` from `node:module` to import package.json
- Export version dynamically from package.json
- Update test to verify VERSION matches package.json

## Why createRequire?

In ESM modules, importing JSON files requires either:
1. Import attributes (`import pkg from './package.json' with { type: 'json' }`) - requires tsconfig changes that would affect output structure
2. `createRequire` - Node.js standard approach for JSON imports in ESM

The `createRequire` approach is cleaner as it doesn't require tsconfig modifications.